### PR TITLE
fix: alerting crq total usage

### DIFF
--- a/charts/pac-quota-controller/Chart.yaml
+++ b/charts/pac-quota-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pac-quota-controller
 description: A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 type: application
-version: 0.4.2
-appVersion: "0.4.2"
+version: 0.4.3
+appVersion: "0.4.3"
 maintainers:
   - name: PowerHome
     url: https://github.com/powerhome

--- a/charts/pac-quota-controller/README.md
+++ b/charts/pac-quota-controller/README.md
@@ -1,6 +1,6 @@
 # pac-quota-controller
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 
@@ -71,7 +71,7 @@ spec:
 This chart can use container images from GitHub Container Registry:
 
 ```console
-ghcr.io/powerhome/pac-quota-controller:0.4.2
+ghcr.io/powerhome/pac-quota-controller:0.4.3
 ```
 
 You can configure which registry to use by modifying the `controllerManager.container.image.repository` value.

--- a/charts/pac-quota-controller/README.md
+++ b/charts/pac-quota-controller/README.md
@@ -145,7 +145,7 @@ The controller exposes the following key metrics:
 - `pac_quota_controller_reconcile_errors_total`: Total number of reconciliation errors.
 - `pac_quota_controller_aggregation_duration_seconds`: A histogram of the time taken to aggregate resource usage for a ClusterResourceQuota.
 - `pac_quota_controller_crq_usage`: Current usage percentage per resource/namespace.
-- `pac_quota_controller_crq_total_usage`: Current aggregated usage percentage per resource.
+- `pac_quota_controller_crq_total_usage`: Current aggregated usage percentage per resource. Includes `namespace` (first selected namespace, for alert routing) and `namespaces` (comma-separated list of all selected namespaces) labels.
 
 ### Alerting Rules
 

--- a/charts/pac-quota-controller/README.md.gotmpl
+++ b/charts/pac-quota-controller/README.md.gotmpl
@@ -149,7 +149,7 @@ The controller exposes the following key metrics:
 - `pac_quota_controller_reconcile_errors_total`: Total number of reconciliation errors.
 - `pac_quota_controller_aggregation_duration_seconds`: A histogram of the time taken to aggregate resource usage for a ClusterResourceQuota.
 - `pac_quota_controller_crq_usage`: Current usage percentage per resource/namespace.
-- `pac_quota_controller_crq_total_usage`: Current aggregated usage percentage per resource.
+- `pac_quota_controller_crq_total_usage`: Current aggregated usage percentage per resource. Includes `namespace` (first selected namespace, for alert routing) and `namespaces` (comma-separated list of all selected namespaces) labels.
 
 
 ### Alerting Rules

--- a/charts/pac-quota-controller/templates/prometheus/alertingrules.yaml
+++ b/charts/pac-quota-controller/templates/prometheus/alertingrules.yaml
@@ -26,7 +26,7 @@ spec:
         - alert: QuotaBreached
           annotations:
             summary: ClusterResourceQuota limit breached
-            description: "ClusterResourceQuota {{`{{ $labels.crq_name }}`}} has exceeded its assigned limit for resource {{`{{ $labels.resource }}`}}."
+            description: "ClusterResourceQuota {{`{{ $labels.crq_name }}`}} has exceeded its assigned limit for resource {{`{{ $labels.resource }}`}} (namespaces: {{`{{ $labels.namespaces }}`}})."
           expr: |
             pac_quota_controller_crq_total_usage > 1.0
           for: {{ .Values.prometheus.alerting.rules.quotaBreach.for }}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,8 +15,10 @@ This controller exposes Prometheus metrics at the `/metrics` endpoint. Below are
 ### `pac_quota_controller_crq_total_usage`
 
 - **Type:** Gauge
-- **Labels:** `crq_name`, `resource`
+- **Labels:** `crq_name`, `resource`, `namespace`, `namespaces`
 - **Description:** Aggregated usage of a resource across all namespaces for a ClusterResourceQuota.
+  - `namespace`: One of the selected namespaces (first alphabetically). Useful for AlertManager routing when routing is based on namespace.
+  - `namespaces`: Comma-separated list of all selected namespaces for the CRQ.
 
 ---
 

--- a/internal/controller/clusterresourcequota_controller.go
+++ b/internal/controller/clusterresourcequota_controller.go
@@ -267,6 +267,12 @@ func (r *ClusterResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl
 			metrics.CRQUsage.WithLabelValues(crq.Name, ns, string(resourceName)).Set(percent)
 		}
 	}
+	// Pick the first namespace (alphabetically) for routing and join all for context
+	var routingNamespace string
+	if len(selectedNamespaces) > 0 {
+		routingNamespace = selectedNamespaces[0]
+	}
+	allNamespaces := strings.Join(selectedNamespaces, ",")
 	for resourceName, total := range totalUsage {
 		hard, hasHard := crq.Spec.Hard[resourceName]
 		var percent float64
@@ -275,7 +281,9 @@ func (r *ClusterResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl
 		} else {
 			percent = 0.0
 		}
-		metrics.CRQTotalUsage.WithLabelValues(crq.Name, string(resourceName)).Set(percent)
+		metrics.CRQTotalUsage.WithLabelValues(
+			crq.Name, string(resourceName), routingNamespace, allNamespaces,
+		).Set(percent)
 	}
 
 	// Update the status of the ClusterResourceQuota

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,7 +20,7 @@ var (
 			Name: "pac_quota_controller_crq_total_usage",
 			Help: "Aggregated usage of a resource across all namespaces for a ClusterResourceQuota.",
 		},
-		[]string{"crq_name", "resource"},
+		[]string{"crq_name", "resource", "namespace", "namespaces"},
 	)
 	WebhookValidationCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

CRQ is cluster-scoped, so `pac_quota_controller_crq_total_usage` had no `namespace` label, making AlertManager routing by namespace impossible.

Added `namespace` (first selected namespace alphabetically) and `namespaces` (comma-separated list of all selected namespaces) labels to `CRQTotalUsage`. This enables existing ServiceMonitor relabeling rules to restore the namespace for alert routing.

## 📚 Documentation

- Updated `docs/metrics.md` with new label descriptions
- Updated Helm chart `README.md` and `README.md.gotmpl`
- Updated `QuotaBreached` alert description to include `namespaces` label

- [x] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [ ] ✅ Added or updated tests for new/changed behavior
- [x] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [X] 🔧 Ran pre-commit hooks to validate changes:
  - [X] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [X] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [X] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [X] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **📝 Note:** Chart and app versioning are manual. See CONTRIBUTING.md for details on how to release.
> **🐙 Note:** For Helm chart installation, use GHCR as an OCI registry. See README for instructions.