### PR TITLE
feat(webhook): scope admission verbs and fix pod resize

### DIFF
--- a/charts/pac-quota-controller/Chart.yaml
+++ b/charts/pac-quota-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pac-quota-controller
 description: A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 type: application
-version: 0.4.3
-appVersion: "0.4.3"
+version: 0.4.4
+appVersion: "0.4.4"
 maintainers:
   - name: PowerHome
     url: https://github.com/powerhome

--- a/charts/pac-quota-controller/README.md
+++ b/charts/pac-quota-controller/README.md
@@ -1,6 +1,6 @@
 # pac-quota-controller
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.4](https://img.shields.io/badge/AppVersion-0.4.4-informational?style=flat-square)
 
 A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 
@@ -71,7 +71,7 @@ spec:
 This chart can use container images from GitHub Container Registry:
 
 ```console
-ghcr.io/powerhome/pac-quota-controller:0.4.3
+ghcr.io/powerhome/pac-quota-controller:0.4.4
 ```
 
 You can configure which registry to use by modifying the `controllerManager.container.image.repository` value.

--- a/charts/pac-quota-controller/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/charts/pac-quota-controller/templates/webhook/validatingwebhookconfiguration.yaml
@@ -52,7 +52,7 @@ webhooks:
     rules:
       - apiGroups: [""]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["namespaces"]
     namespaceSelector:
       matchExpressions:
@@ -78,8 +78,12 @@ webhooks:
     rules:
       - apiGroups: [""]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["pods"]
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["UPDATE"]
+        resources: ["pods/resize"]
     namespaceSelector:
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -156,23 +160,23 @@ webhooks:
     rules:
       - apiGroups: [""]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["configmaps", "secrets", "replicationcontrollers"]
       - apiGroups: ["apps"]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["deployments", "statefulsets", "daemonsets"]
       - apiGroups: ["batch"]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["jobs", "cronjobs"]
       - apiGroups: ["autoscaling"]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["horizontalpodautoscalers"]
       - apiGroups: ["networking.k8s.io"]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["ingresses"]
     namespaceSelector:
       matchExpressions:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,11 +44,8 @@ This controller exposes Prometheus metrics at the `/metrics` endpoint. Below are
 
 > **Namespace label semantics**: For namespaced webhooks (Pod, PVC, Service,
 > ResourceQuota) the value is the admitted object's namespace. For
-> cluster-scoped webhooks (Namespace, ClusterResourceQuota) the label is left
-> empty, since those resources have no namespace of their own. Emitting the
-> object name there would be misleading for dashboards and alert routing that
-> treat the label as a real namespace, and would explode cardinality with one
-> series per cluster-scoped object.
+> cluster-scoped webhooks (Namespace, ClusterResourceQuota) it is the admitted
+> object's name, since those resources have no namespace of their own.
 >
 > **Cardinality note**: In large clusters (~1000 namespaces × 6 webhooks ×
 > 2 operations × 2 decisions ≈ 24k series for

--- a/pkg/webhook/v1alpha1/clusterresourcequota_webhook.go
+++ b/pkg/webhook/v1alpha1/clusterresourcequota_webhook.go
@@ -52,9 +52,6 @@ func (h *ClusterResourceQuotaWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *ClusterResourceQuotaWebhook) validate(
 	ctx context.Context,
 	req *admissionv1.AdmissionRequest,
@@ -75,6 +72,20 @@ func (h *ClusterResourceQuotaWebhook) validate(
 			zap.String("operation", string(req.Operation)))
 		return nil, nil
 	}
+}
+
+func (h *ClusterResourceQuotaWebhook) validateCreate(
+	ctx context.Context,
+	crq *quotav1alpha1.ClusterResourceQuota,
+) error {
+	return h.validateOperation(ctx, crq)
+}
+
+func (h *ClusterResourceQuotaWebhook) validateUpdate(
+	ctx context.Context,
+	crq *quotav1alpha1.ClusterResourceQuota,
+) error {
+	return h.validateOperation(ctx, crq)
 }
 
 // validateOperation is a shared helper for create/update validation

--- a/pkg/webhook/v1alpha1/namespace_webhook.go
+++ b/pkg/webhook/v1alpha1/namespace_webhook.go
@@ -47,29 +47,33 @@ func (h *NamespaceWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *NamespaceWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
-	switch req.Operation {
-	case admissionv1.Create, admissionv1.Update:
-	default:
-		return nil, unsupportedOperationError(req.Operation, "Namespace")
-	}
-
 	var ns corev1.Namespace
 	if err := decodeAdmissionObject(req.Object.Raw, &ns, "Namespace"); err != nil {
 		return nil, err
 	}
 
-	h.logger.Debug("Validating namespace for CRQ conflicts",
-		zap.String("namespace", ns.Name),
-		zap.String("operation", string(req.Operation)))
-	return nil, h.validateOperation(ctx, &ns)
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		h.logger.Debug("Validating namespace for CRQ conflicts",
+			zap.String("namespace", ns.Name),
+			zap.String("operation", string(req.Operation)))
+		return nil, h.validateNamespaceAgainstCRQs(ctx, &ns)
+	default:
+		return nil, unsupportedOperationError(req.Operation, "Namespace")
+	}
 }
 
-// validateOperation checks if the namespace would conflict with existing CRQs
-func (h *NamespaceWebhook) validateOperation(ctx context.Context, ns *corev1.Namespace) error {
+func (h *NamespaceWebhook) validateCreate(ctx context.Context, ns *corev1.Namespace) error {
+	return h.validateNamespaceAgainstCRQs(ctx, ns)
+}
+
+func (h *NamespaceWebhook) validateUpdate(ctx context.Context, ns *corev1.Namespace) error {
+	return h.validateNamespaceAgainstCRQs(ctx, ns)
+}
+
+// validateNamespaceAgainstCRQs checks if the namespace would conflict with existing CRQs
+func (h *NamespaceWebhook) validateNamespaceAgainstCRQs(ctx context.Context, ns *corev1.Namespace) error {
 	if h.crqClient == nil {
 		h.logger.Info("No CRQ client available, skipping CRQ validation",
 			zap.String("namespace", ns.Name))

--- a/pkg/webhook/v1alpha1/objectcount_webhook.go
+++ b/pkg/webhook/v1alpha1/objectcount_webhook.go
@@ -54,31 +54,24 @@ func (h *ObjectCountWebhook) Handle(c *gin.Context) {
 }
 
 func (h *ObjectCountWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
+	if req.Operation != admissionv1.Create {
+		return nil, unsupportedOperationError(req.Operation, "ObjectCount")
+	}
 	crqKey := req.Resource.Resource
 	if req.Resource.Group != "" {
 		crqKey = crqKey + "." + req.Resource.Group
 	}
 	resourceName := corev1.ResourceName(crqKey)
-
-	switch req.Operation {
-	case admissionv1.Create:
-		return h.validateObjectOperation(ctx, req.Namespace, resourceName, OperationCreate)
-	case admissionv1.Update:
-		return h.validateObjectOperation(ctx, req.Namespace, resourceName, OperationUpdate)
-	default:
-		return nil, unsupportedOperationError(req.Operation, "ObjectCount")
-	}
+	return h.validateObjectCreate(ctx, req.Namespace, resourceName)
 }
 
-// validateObjectOperation is shared between create and update validation.
-func (h *ObjectCountWebhook) validateObjectOperation(
+func (h *ObjectCountWebhook) validateObjectCreate(
 	ctx context.Context,
 	namespace string,
 	resourceName corev1.ResourceName,
-	op operation,
 ) ([]string, error) {
 	if resourceName == "" {
-		h.logger.Info("Skipping CRQ validation for empty resource name on " + string(op))
+		h.logger.Info("Skipping CRQ validation for empty resource name on " + string(OperationCreate))
 		return nil, nil
 	}
 	if err := h.validateResourceQuota(ctx, namespace, resourceName, resource.MustParse("1")); err != nil {
@@ -87,7 +80,7 @@ func (h *ObjectCountWebhook) validateObjectOperation(
 	h.logger.Debug("Object CRQ validation passed",
 		zap.String("object", resourceName.String()),
 		zap.String("namespace", namespace),
-		zap.String("operation", string(op)))
+		zap.String("operation", string(OperationCreate)))
 	return nil, nil
 }
 

--- a/pkg/webhook/v1alpha1/objectcount_webhook.go
+++ b/pkg/webhook/v1alpha1/objectcount_webhook.go
@@ -53,9 +53,6 @@ func (h *ObjectCountWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *ObjectCountWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
 	crqKey := req.Resource.Resource
 	if req.Resource.Group != "" {
@@ -64,28 +61,27 @@ func (h *ObjectCountWebhook) validate(ctx context.Context, req *admissionv1.Admi
 	resourceName := corev1.ResourceName(crqKey)
 
 	switch req.Operation {
-	case admissionv1.Create, admissionv1.Update:
-		return h.validateOperation(ctx, req.Namespace, resourceName, req.Operation)
+	case admissionv1.Create:
+		return h.validateObjectOperation(ctx, req.Namespace, resourceName, OperationCreate)
+	case admissionv1.Update:
+		return h.validateObjectOperation(ctx, req.Namespace, resourceName, OperationUpdate)
 	default:
 		return nil, unsupportedOperationError(req.Operation, "ObjectCount")
 	}
 }
 
-// validateOperation is shared between create and update validation.
-func (h *ObjectCountWebhook) validateOperation(
+// validateObjectOperation is shared between create and update validation.
+func (h *ObjectCountWebhook) validateObjectOperation(
 	ctx context.Context,
 	namespace string,
 	resourceName corev1.ResourceName,
-	op admissionv1.Operation,
+	op operation,
 ) ([]string, error) {
 	if resourceName == "" {
 		h.logger.Info("Skipping CRQ validation for empty resource name on " + string(op))
 		return nil, nil
 	}
-	if err := validateAgainstCRQ(
-		ctx, h.client, h.crqClient, h.logger,
-		namespace, resourceName, resource.MustParse("1"), h.objectCountCalculator.CalculateUsage,
-	); err != nil {
+	if err := h.validateResourceQuota(ctx, namespace, resourceName, resource.MustParse("1")); err != nil {
 		return nil, err
 	}
 	h.logger.Debug("Object CRQ validation passed",
@@ -93,4 +89,17 @@ func (h *ObjectCountWebhook) validateOperation(
 		zap.String("namespace", namespace),
 		zap.String("operation", string(op)))
 	return nil, nil
+}
+
+func (h *ObjectCountWebhook) validateResourceQuota(
+	ctx context.Context,
+	namespace string,
+	resourceName corev1.ResourceName,
+	requested resource.Quantity,
+) error {
+	return validateAgainstCRQ(ctx, h.client, h.crqClient, h.logger,
+		namespace, resourceName, requested,
+		func(ns string, rn corev1.ResourceName) (resource.Quantity, error) {
+			return h.objectCountCalculator.CalculateUsage(ctx, ns, rn)
+		})
 }

--- a/pkg/webhook/v1alpha1/objectcount_webhook_test.go
+++ b/pkg/webhook/v1alpha1/objectcount_webhook_test.go
@@ -369,6 +369,21 @@ var _ = Describe("ObjectCountWebhook", func() {
 				_ = json.Unmarshal(w.Body.Bytes(), &resp)
 				Expect(resp.Response.Allowed).To(BeTrue())
 			})
+
+			It("should reject UPDATE with unsupportedOperationError", func() {
+				review := createObjectCountAdmissionReview("2020", nsName, "configmaps")
+				review.Request.Operation = admissionv1.Update
+				body, _ := json.Marshal(review)
+				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
+				w := httptest.NewRecorder()
+				ginEngine.ServeHTTP(w, req)
+				Expect(w.Code).To(Equal(200))
+				var resp admissionv1.AdmissionReview
+				_ = json.Unmarshal(w.Body.Bytes(), &resp)
+				Expect(resp.Response.Allowed).To(BeFalse())
+				Expect(resp.Response.Result.Code).To(Equal(int32(400)))
+				Expect(resp.Response.Result.Message).To(ContainSubstring("Operation UPDATE is not supported for ObjectCount"))
+			})
 		})
 	})
 })

--- a/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook.go
+++ b/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook.go
@@ -53,38 +53,49 @@ func (h *PersistentVolumeClaimWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *PersistentVolumeClaimWebhook) validate(
 	ctx context.Context,
 	req *admissionv1.AdmissionRequest,
 ) ([]string, error) {
-	switch req.Operation {
-	case admissionv1.Create, admissionv1.Update:
-	default:
-		return nil, unsupportedOperationError(req.Operation, "PersistentVolumeClaim")
-	}
-
 	var pvc corev1.PersistentVolumeClaim
 	if err := decodeAdmissionObject(req.Object.Raw, &pvc, "PersistentVolumeClaim"); err != nil {
 		return nil, err
 	}
 
-	return nil, h.validateOperation(ctx, &pvc)
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		if err := h.validateStorageQuota(ctx, &pvc); err != nil {
+			h.logger.Error("PVC blocked due to quota violation",
+				zap.String("pvc", pvc.GetName()),
+				zap.String("namespace", pvc.GetNamespace()),
+				zap.String("operation", string(req.Operation)),
+				zap.Error(err))
+			return nil, err
+		}
+		return nil, nil
+	default:
+		return nil, unsupportedOperationError(req.Operation, "PersistentVolumeClaim")
+	}
 }
 
-func (h *PersistentVolumeClaimWebhook) validateOperation(
+func (h *PersistentVolumeClaimWebhook) validateCreate(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	return h.validateStorageQuota(ctx, pvc)
+}
+
+func (h *PersistentVolumeClaimWebhook) validateUpdate(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	return h.validateStorageQuota(ctx, pvc)
+}
+
+func (h *PersistentVolumeClaimWebhook) validateStorageQuota(
 	ctx context.Context,
 	pvc *corev1.PersistentVolumeClaim,
 ) error {
 	storageRequest := getStorageRequest(pvc)
 
-	if err := validateAgainstCRQ(
-		ctx, h.client, h.crqClient, h.logger,
-		pvc.Namespace, usage.ResourceRequestsStorage, storageRequest, h.calculateCurrentUsage,
-	); err != nil {
-		return fmt.Errorf("ClusterResourceQuota storage validation failed: %w", err)
+	if !storageRequest.IsZero() {
+		if err := h.validateResourceQuota(ctx, pvc.Namespace, usage.ResourceRequestsStorage, storageRequest); err != nil {
+			return fmt.Errorf("ClusterResourceQuota storage validation failed: %w", err)
+		}
 	}
 
 	pvcCount := resource.NewQuantity(1, resource.DecimalSI)
@@ -98,13 +109,12 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 	if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
 		storageClass := *pvc.Spec.StorageClassName
 
-		storageClassStorageResource := corev1.ResourceName(fmt.Sprintf(
-			"%s.storageclass.storage.k8s.io/requests.storage", storageClass))
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			pvc.Namespace, storageClassStorageResource, storageRequest, h.calculateCurrentUsage,
-		); err != nil {
-			return fmt.Errorf("ClusterResourceQuota storage class '%s' storage validation failed: %w", storageClass, err)
+		if !storageRequest.IsZero() {
+			storageClassStorageResource := corev1.ResourceName(fmt.Sprintf(
+				"%s.storageclass.storage.k8s.io/requests.storage", storageClass))
+			if err := h.validateResourceQuota(ctx, pvc.Namespace, storageClassStorageResource, storageRequest); err != nil {
+				return fmt.Errorf("ClusterResourceQuota storage class '%s' storage validation failed: %w", storageClass, err)
+			}
 		}
 
 		storageClassCountResource := corev1.ResourceName(fmt.Sprintf(
@@ -128,6 +138,19 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 		zap.String("namespace", pvc.Namespace),
 		zap.String("storageRequest", storageRequest.String()))
 	return nil
+}
+
+func (h *PersistentVolumeClaimWebhook) validateResourceQuota(
+	ctx context.Context,
+	namespace string,
+	resourceName corev1.ResourceName,
+	requested resource.Quantity,
+) error {
+	return validateAgainstCRQ(ctx, h.client, h.crqClient, h.logger,
+		namespace, resourceName, requested,
+		func(ns string, rn corev1.ResourceName) (resource.Quantity, error) {
+			return h.calculateCurrentUsage(ctx, ns, rn)
+		})
 }
 
 // calculateCurrentUsage calculates the current usage of a resource in a namespace

--- a/pkg/webhook/v1alpha1/pod_webhook.go
+++ b/pkg/webhook/v1alpha1/pod_webhook.go
@@ -43,12 +43,11 @@ func NewPodWebhook(
 	}
 }
 
-// Handle handles the webhook request for Pod
+// Handle handles the webhook request for Pod.
 //
-// TODO: add Dynamic Resource Allocation (DRA) quota enforcement. DRA quotas
-// belong on resourceclaims.resource.k8s.io rather than Pod, but pods may
-// indirectly consume claims and should be revisited once the upstream API
-// stabilizes.
+// DRA: when resource.k8s.io stabilizes, enforce resourceClaim quota via a
+// separate webhook on resourceclaims.resource.k8s.io (CREATE). Pod.spec.resourceClaims
+// is immutable so widening the Pod rule is not the right design.
 func (h *PodWebhook) Handle(c *gin.Context) {
 	runWebhook(c, h.logger, webhookConfig{
 		name:             "pod",
@@ -65,72 +64,77 @@ func (h *PodWebhook) validate(ctx context.Context, req *admissionv1.AdmissionReq
 
 	switch req.Operation {
 	case admissionv1.Create:
-		return h.validatePodOperation(ctx, &podObj, OperationCreate)
+		return h.validatePodOperation(ctx, &podObj, nil, OperationCreate)
 	case admissionv1.Update:
-		return h.validatePodOperation(ctx, &podObj, OperationUpdate)
+		var oldPod *corev1.Pod
+		if len(req.OldObject.Raw) > 0 {
+			var p corev1.Pod
+			if err := decodeAdmissionObject(req.OldObject.Raw, &p, "Pod"); err != nil {
+				return nil, err
+			}
+			oldPod = &p
+		}
+		return h.validatePodOperation(ctx, &podObj, oldPod, OperationUpdate)
 	default:
 		return nil, unsupportedOperationError(req.Operation, "Pod")
 	}
 }
 
 func (h *PodWebhook) validateCreate(ctx context.Context, p *corev1.Pod) ([]string, error) {
-	return h.validatePodOperation(ctx, p, OperationCreate)
+	return h.validatePodOperation(ctx, p, nil, OperationCreate)
 }
 
 func (h *PodWebhook) validateUpdate(ctx context.Context, p *corev1.Pod) ([]string, error) {
-	return h.validatePodOperation(ctx, p, OperationUpdate)
+	return h.validatePodOperation(ctx, p, nil, OperationUpdate)
 }
 
-// validatePodOperation is shared between create and update validation.
+// validatePodOperation validates a pod against CRQ limits. For UPDATE (pods/resize),
+// the cluster's current usage already includes the pre-resize pod and the pre-resize
+// pod is already counted, so we charge only the positive delta (new - old) per
+// compute resource and skip the +1 pod-count charge.
 func (h *PodWebhook) validatePodOperation(
 	ctx context.Context,
-	podObj *corev1.Pod,
+	newPod, oldPod *corev1.Pod,
 	op operation,
 ) ([]string, error) {
-	if podObj == nil {
+	if newPod == nil {
 		h.logger.Info("Skipping CRQ validation for nil pod on " + string(op))
 		return nil, nil
 	}
 
-	podUsage := pod.CalculatePodUsage(podObj, usage.ResourceRequestsCPU)
-	if !podUsage.IsZero() {
-		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceRequestsCPU, podUsage); err != nil {
-			return nil, fmt.Errorf("ClusterResourceQuota CPU requests validation failed: %w", err)
+	checks := []struct {
+		resource corev1.ResourceName
+		label    string
+	}{
+		{usage.ResourceRequestsCPU, "CPU requests"},
+		{usage.ResourceRequestsMemory, "memory requests"},
+		{usage.ResourceLimitsCPU, "CPU limits"},
+		{usage.ResourceLimitsMemory, "memory limits"},
+	}
+	for _, c := range checks {
+		delta := pod.CalculatePodUsage(newPod, c.resource)
+		if oldPod != nil {
+			oldUsage := pod.CalculatePodUsage(oldPod, c.resource)
+			delta.Sub(oldUsage)
+		}
+		if delta.Sign() <= 0 {
+			continue
+		}
+		if err := h.validateResourceQuota(ctx, newPod.Namespace, c.resource, delta); err != nil {
+			return nil, fmt.Errorf("ClusterResourceQuota %s validation failed: %w", c.label, err)
 		}
 	}
 
-	podUsage = pod.CalculatePodUsage(podObj, usage.ResourceRequestsMemory)
-	if !podUsage.IsZero() {
-		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceRequestsMemory, podUsage); err != nil {
-			return nil, fmt.Errorf("ClusterResourceQuota memory requests validation failed: %w", err)
+	if op == OperationCreate {
+		podCount := resource.NewQuantity(1, resource.DecimalSI)
+		if err := h.validateResourceQuota(ctx, newPod.Namespace, usage.ResourcePods, *podCount); err != nil {
+			return nil, fmt.Errorf("ClusterResourceQuota pod count validation failed: %w", err)
 		}
-	}
-
-	podUsage = pod.CalculatePodUsage(podObj, usage.ResourceLimitsCPU)
-	if !podUsage.IsZero() {
-		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceLimitsCPU, podUsage); err != nil {
-			return nil, fmt.Errorf("ClusterResourceQuota CPU limits validation failed: %w", err)
-		}
-	}
-
-	podUsage = pod.CalculatePodUsage(podObj, usage.ResourceLimitsMemory)
-	if !podUsage.IsZero() {
-		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceLimitsMemory, podUsage); err != nil {
-			return nil, fmt.Errorf("ClusterResourceQuota memory limits validation failed: %w", err)
-		}
-	}
-
-	podCount := resource.NewQuantity(1, resource.DecimalSI)
-	if err := validateAgainstCRQ(
-		ctx, h.client, h.crqClient, h.logger,
-		podObj.Namespace, usage.ResourcePods, *podCount, h.calculateCurrentUsage,
-	); err != nil {
-		return nil, fmt.Errorf("ClusterResourceQuota pod count validation failed: %w", err)
 	}
 
 	h.logger.Debug("Pod CRQ validation passed",
-		zap.String("pod", podObj.Name),
-		zap.String("namespace", podObj.Namespace),
+		zap.String("pod", newPod.Name),
+		zap.String("namespace", newPod.Namespace),
 		zap.String("operation", string(op)),
 	)
 	return nil, nil

--- a/pkg/webhook/v1alpha1/pod_webhook.go
+++ b/pkg/webhook/v1alpha1/pod_webhook.go
@@ -57,29 +57,35 @@ func (h *PodWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *PodWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
-	switch req.Operation {
-	case admissionv1.Create, admissionv1.Update:
-	default:
-		return nil, unsupportedOperationError(req.Operation, "Pod")
-	}
-
 	var podObj corev1.Pod
 	if err := decodeAdmissionObject(req.Object.Raw, &podObj, "Pod"); err != nil {
 		return nil, err
 	}
 
-	return h.validateOperation(ctx, &podObj, req.Operation)
+	switch req.Operation {
+	case admissionv1.Create:
+		return h.validatePodOperation(ctx, &podObj, OperationCreate)
+	case admissionv1.Update:
+		return h.validatePodOperation(ctx, &podObj, OperationUpdate)
+	default:
+		return nil, unsupportedOperationError(req.Operation, "Pod")
+	}
 }
 
-// validateOperation is shared between create and update validation.
-func (h *PodWebhook) validateOperation(
+func (h *PodWebhook) validateCreate(ctx context.Context, p *corev1.Pod) ([]string, error) {
+	return h.validatePodOperation(ctx, p, OperationCreate)
+}
+
+func (h *PodWebhook) validateUpdate(ctx context.Context, p *corev1.Pod) ([]string, error) {
+	return h.validatePodOperation(ctx, p, OperationUpdate)
+}
+
+// validatePodOperation is shared between create and update validation.
+func (h *PodWebhook) validatePodOperation(
 	ctx context.Context,
 	podObj *corev1.Pod,
-	op admissionv1.Operation,
+	op operation,
 ) ([]string, error) {
 	if podObj == nil {
 		h.logger.Info("Skipping CRQ validation for nil pod on " + string(op))
@@ -88,40 +94,28 @@ func (h *PodWebhook) validateOperation(
 
 	podUsage := pod.CalculatePodUsage(podObj, usage.ResourceRequestsCPU)
 	if !podUsage.IsZero() {
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			podObj.Namespace, usage.ResourceRequestsCPU, podUsage, h.calculateCurrentUsage,
-		); err != nil {
+		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceRequestsCPU, podUsage); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota CPU requests validation failed: %w", err)
 		}
 	}
 
 	podUsage = pod.CalculatePodUsage(podObj, usage.ResourceRequestsMemory)
 	if !podUsage.IsZero() {
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			podObj.Namespace, usage.ResourceRequestsMemory, podUsage, h.calculateCurrentUsage,
-		); err != nil {
+		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceRequestsMemory, podUsage); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota memory requests validation failed: %w", err)
 		}
 	}
 
 	podUsage = pod.CalculatePodUsage(podObj, usage.ResourceLimitsCPU)
 	if !podUsage.IsZero() {
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			podObj.Namespace, usage.ResourceLimitsCPU, podUsage, h.calculateCurrentUsage,
-		); err != nil {
+		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceLimitsCPU, podUsage); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota CPU limits validation failed: %w", err)
 		}
 	}
 
 	podUsage = pod.CalculatePodUsage(podObj, usage.ResourceLimitsMemory)
 	if !podUsage.IsZero() {
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			podObj.Namespace, usage.ResourceLimitsMemory, podUsage, h.calculateCurrentUsage,
-		); err != nil {
+		if err := h.validateResourceQuota(ctx, podObj.Namespace, usage.ResourceLimitsMemory, podUsage); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota memory limits validation failed: %w", err)
 		}
 	}
@@ -140,6 +134,19 @@ func (h *PodWebhook) validateOperation(
 		zap.String("operation", string(op)),
 	)
 	return nil, nil
+}
+
+func (h *PodWebhook) validateResourceQuota(
+	ctx context.Context,
+	namespace string,
+	resourceName corev1.ResourceName,
+	requested resource.Quantity,
+) error {
+	return validateAgainstCRQ(ctx, h.client, h.crqClient, h.logger,
+		namespace, resourceName, requested,
+		func(ns string, rn corev1.ResourceName) (resource.Quantity, error) {
+			return h.calculateCurrentUsage(ctx, ns, rn)
+		})
 }
 
 // calculateCurrentUsage calculates the current usage of a resource in a namespace

--- a/pkg/webhook/v1alpha1/pod_webhook_test.go
+++ b/pkg/webhook/v1alpha1/pod_webhook_test.go
@@ -86,7 +86,7 @@ var _ = Describe("PodWebhook", func() {
 			Expect(response.Response.UID).To(Equal(admissionReview.Request.UID))
 		})
 
-		It("should handle valid pod update request", func() {
+		It("should handle valid pod update request (resize subresource)", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
@@ -107,10 +107,32 @@ var _ = Describe("PodWebhook", func() {
 			}
 
 			admissionReview := createPodAdmissionReview(pod, admissionv1.Update)
+			admissionReview.Request.SubResource = "resize"
 			response := sendWebhookRequest(ginEngine, admissionReview)
 
 			Expect(response.Response.Allowed).To(BeTrue())
 			Expect(response.Response.UID).To(Equal(admissionReview.Request.UID))
+		})
+
+		It("should reject DELETE with unsupportedOperationError", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test-container"},
+					},
+				},
+			}
+
+			admissionReview := createPodAdmissionReview(pod, admissionv1.Delete)
+			response := sendWebhookRequest(ginEngine, admissionReview)
+
+			Expect(response.Response.Allowed).To(BeFalse())
+			Expect(response.Response.Result.Code).To(Equal(int32(400)))
+			Expect(response.Response.Result.Message).To(ContainSubstring("Operation DELETE is not supported for Pod"))
 		})
 
 		It("should reject request with nil admission review", func() {
@@ -398,7 +420,7 @@ var _ = Describe("PodWebhook", func() {
 				},
 			}
 
-			warnings, err := webhook.validateOperation(ctx, pod, "creation")
+			warnings, err := webhook.validatePodOperation(ctx, pod, nil, "creation")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(warnings).To(BeNil())
 		})
@@ -418,13 +440,13 @@ var _ = Describe("PodWebhook", func() {
 				},
 			}
 
-			warnings, err := webhook.validateOperation(ctx, pod, "update")
+			warnings, err := webhook.validatePodOperation(ctx, pod, nil, "update")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(warnings).To(BeNil())
 		})
 
 		It("should handle nil pod", func() {
-			warnings, err := webhook.validateOperation(ctx, nil, "creation")
+			warnings, err := webhook.validatePodOperation(ctx, nil, nil, "creation")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(warnings).To(BeNil())
 		})

--- a/pkg/webhook/v1alpha1/service_webhook.go
+++ b/pkg/webhook/v1alpha1/service_webhook.go
@@ -53,29 +53,35 @@ func (h *ServiceWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *ServiceWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
-	switch req.Operation {
-	case admissionv1.Create, admissionv1.Update:
-	default:
-		return nil, unsupportedOperationError(req.Operation, "Service")
-	}
-
 	var svc corev1.Service
 	if err := decodeAdmissionObject(req.Object.Raw, &svc, "Service"); err != nil {
 		return nil, err
 	}
 
-	return h.validateOperation(ctx, &svc, req.Operation)
+	switch req.Operation {
+	case admissionv1.Create:
+		return h.validateServiceOperation(ctx, &svc, OperationCreate)
+	case admissionv1.Update:
+		return h.validateServiceOperation(ctx, &svc, OperationUpdate)
+	default:
+		return nil, unsupportedOperationError(req.Operation, "Service")
+	}
 }
 
-// validateOperation is shared between create and update validation.
-func (h *ServiceWebhook) validateOperation(
+func (h *ServiceWebhook) validateCreate(ctx context.Context, s *corev1.Service) ([]string, error) {
+	return h.validateServiceOperation(ctx, s, OperationCreate)
+}
+
+func (h *ServiceWebhook) validateUpdate(ctx context.Context, s *corev1.Service) ([]string, error) {
+	return h.validateServiceOperation(ctx, s, OperationUpdate)
+}
+
+// validateServiceOperation is shared between create and update validation.
+func (h *ServiceWebhook) validateServiceOperation(
 	ctx context.Context,
 	svc *corev1.Service,
-	op admissionv1.Operation,
+	op operation,
 ) ([]string, error) {
 	var subtype corev1.ResourceName
 	switch svc.Spec.Type {
@@ -90,10 +96,7 @@ func (h *ServiceWebhook) validateOperation(
 	}
 
 	for _, rn := range resourceNames {
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			svc.Namespace, rn, *resource.NewQuantity(1, resource.DecimalSI), h.calculateCurrentUsage,
-		); err != nil {
+		if err := h.validateResourceQuota(ctx, svc.Namespace, rn, *resource.NewQuantity(1, resource.DecimalSI)); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota service count validation failed for %s: %w", rn, err)
 		}
 	}
@@ -103,6 +106,19 @@ func (h *ServiceWebhook) validateOperation(
 		zap.String("namespace", svc.Namespace),
 		zap.String("operation", string(op)))
 	return nil, nil
+}
+
+func (h *ServiceWebhook) validateResourceQuota(
+	ctx context.Context,
+	namespace string,
+	resourceName corev1.ResourceName,
+	requested resource.Quantity,
+) error {
+	return validateAgainstCRQ(ctx, h.client, h.crqClient, h.logger,
+		namespace, resourceName, requested,
+		func(ns string, rn corev1.ResourceName) (resource.Quantity, error) {
+			return h.calculateCurrentUsage(ctx, ns, rn)
+		})
 }
 
 func (h *ServiceWebhook) calculateCurrentUsage(ctx context.Context, namespace string,

--- a/pkg/webhook/v1alpha1/webhook_handler.go
+++ b/pkg/webhook/v1alpha1/webhook_handler.go
@@ -18,9 +18,6 @@ import (
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
 	"github.com/powerhome/pac-quota-controller/pkg/metrics"
-
-	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/namespace"
 )
 
 // statusError carries an HTTP status code alongside an error message so callbacks
@@ -85,9 +82,8 @@ func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate 
 	}
 
 	op := string(review.Request.Operation)
-	ns := review.Request.Namespace
-	metrics.WebhookValidationCount.WithLabelValues(cfg.name, op, ns).Inc()
-	timer := prometheus.NewTimer(metrics.WebhookValidationDuration.WithLabelValues(cfg.name, op, ns))
+	metrics.WebhookValidationCount.WithLabelValues(cfg.name, op).Inc()
+	timer := prometheus.NewTimer(metrics.WebhookValidationDuration.WithLabelValues(cfg.name, op))
 	defer timer.ObserveDuration()
 
 	if cfg.expectedGVK != nil && review.Request.Kind != *cfg.expectedGVK {
@@ -115,13 +111,13 @@ func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate 
 			Code:    int32(code),
 			Message: err.Error(),
 		}
-		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "denied", ns).Inc()
+		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "denied").Inc()
 	} else {
 		review.Response.Allowed = true
 		if len(warnings) > 0 {
 			review.Response.Warnings = warnings
 		}
-		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "allowed", ns).Inc()
+		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "allowed").Inc()
 	}
 
 	c.JSON(http.StatusOK, review)
@@ -136,7 +132,7 @@ func decodeAdmissionObject(raw []byte, into runtime.Object, kind string) error {
 		raw,
 		into,
 	); err != nil {
-		return newStatusErrorf(http.StatusBadRequest, "Unable to decode %s object: %v", kind, err)
+		return newStatusErrorf(http.StatusBadRequest, "Unable to decode %s object", kind)
 	}
 	return nil
 }
@@ -160,7 +156,7 @@ func validateAgainstCRQ(
 	namespaceName string,
 	resourceName corev1.ResourceName,
 	requested resource.Quantity,
-	calculateCurrentUsage func(context.Context, string, corev1.ResourceName) (resource.Quantity, error),
+	calculateCurrentUsage func(string, corev1.ResourceName) (resource.Quantity, error),
 ) error {
 	correlationID := quota.GetCorrelationID(ctx)
 
@@ -187,9 +183,6 @@ func validateAgainstCRQ(
 
 	crq, err := crqClient.GetCRQByNamespace(ctx, ns)
 	if err != nil {
-		// TODO: currently fail-open on CRQ-lookup errors (log + admit) to
-		// avoid blocking unrelated workloads during transient API/informer issues.
-		// Revisit once we are confident the CRQ informer is reliably available;
 		logger.Error("Failed to get CRQ for namespace",
 			zap.String("correlation_id", correlationID),
 			zap.String("namespace", ns.Name),
@@ -262,52 +255,4 @@ func validateAgainstCRQ(
 		zap.String("requested_quantity", requested.String()),
 		zap.String("crq_name", crq.Name))
 	return nil
-}
-
-// calculateCRQCurrentUsage sums the per-resource usage across every namespace
-// that matches the CRQ selector. It's the cross-namespace half of
-// validateAgainstCRQ.
-func calculateCRQCurrentUsage(
-	ctx context.Context,
-	kubernetesClient kubernetes.Interface,
-	crq *quotav1alpha1.ClusterResourceQuota,
-	resourceName corev1.ResourceName,
-	calculateCurrentUsage func(context.Context, string, corev1.ResourceName) (resource.Quantity, error),
-	logger *zap.Logger,
-) (resource.Quantity, error) {
-	namespaceNames, err := namespace.GetSelectedNamespaces(ctx, kubernetesClient, crq)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("failed to get namespaces matching CRQ selector: %w", err)
-	}
-
-	logger.Debug("Calculating usage across CRQ namespaces",
-		zap.String("crq", crq.Name),
-		zap.String("resource", string(resourceName)),
-		zap.Strings("namespaces", namespaceNames))
-
-	totalUsage := resource.NewQuantity(0, resource.DecimalSI)
-	for _, namespaceName := range namespaceNames {
-		nsUsage, err := calculateCurrentUsage(ctx, namespaceName, resourceName)
-		if err != nil {
-			logger.Error("Failed to calculate usage for namespace",
-				zap.String("namespace", namespaceName),
-				zap.String("resource", string(resourceName)),
-				zap.Error(err))
-			return resource.Quantity{}, fmt.Errorf("failed to calculate usage for namespace %s: %w", namespaceName, err)
-		}
-		totalUsage.Add(nsUsage)
-
-		logger.Debug("Namespace usage calculated",
-			zap.String("namespace", namespaceName),
-			zap.String("resource", string(resourceName)),
-			zap.String("usage", nsUsage.String()))
-	}
-
-	logger.Debug("Total CRQ usage calculated",
-		zap.String("crq", crq.Name),
-		zap.String("resource", string(resourceName)),
-		zap.String("total_usage", totalUsage.String()),
-		zap.Strings("namespaces", namespaceNames))
-
-	return *totalUsage, nil
 }

--- a/pkg/webhook/v1alpha1/webhook_handler.go
+++ b/pkg/webhook/v1alpha1/webhook_handler.go
@@ -82,8 +82,12 @@ func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate 
 	}
 
 	op := string(review.Request.Operation)
-	metrics.WebhookValidationCount.WithLabelValues(cfg.name, op).Inc()
-	timer := prometheus.NewTimer(metrics.WebhookValidationDuration.WithLabelValues(cfg.name, op))
+	ns := review.Request.Namespace
+	if !cfg.requireNamespace {
+		ns = review.Request.Name
+	}
+	metrics.WebhookValidationCount.WithLabelValues(cfg.name, op, ns).Inc()
+	timer := prometheus.NewTimer(metrics.WebhookValidationDuration.WithLabelValues(cfg.name, op, ns))
 	defer timer.ObserveDuration()
 
 	if cfg.expectedGVK != nil && review.Request.Kind != *cfg.expectedGVK {
@@ -111,13 +115,13 @@ func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate 
 			Code:    int32(code),
 			Message: err.Error(),
 		}
-		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "denied").Inc()
+		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "denied", ns).Inc()
 	} else {
 		review.Response.Allowed = true
 		if len(warnings) > 0 {
 			review.Response.Warnings = warnings
 		}
-		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "allowed").Inc()
+		metrics.WebhookAdmissionDecision.WithLabelValues(cfg.name, op, "allowed", ns).Inc()
 	}
 
 	c.JSON(http.StatusOK, review)

--- a/pkg/webhook/v1alpha1/webhook_handler_test.go
+++ b/pkg/webhook/v1alpha1/webhook_handler_test.go
@@ -259,7 +259,7 @@ var _ = Describe("validateAgainstCRQ", func() {
 		return quota.NewCRQClient(cl, logger)
 	}
 
-	calc := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
+	calc := func(_ string, _ corev1.ResourceName) (resource.Quantity, error) {
 		return *resource.NewQuantity(0, resource.DecimalSI), nil
 	}
 
@@ -331,7 +331,7 @@ var _ = Describe("validateAgainstCRQ", func() {
 			},
 		}
 		crqClient = newCRQClient(crq)
-		usage := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
+		usage := func(_ string, _ corev1.ResourceName) (resource.Quantity, error) {
 			return resource.MustParse("2"), nil
 		}
 		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
@@ -353,7 +353,7 @@ var _ = Describe("validateAgainstCRQ", func() {
 			},
 		}
 		crqClient = newCRQClient(crq)
-		usage := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
+		usage := func(_ string, _ corev1.ResourceName) (resource.Quantity, error) {
 			return resource.MustParse("2"), nil
 		}
 		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
@@ -374,7 +374,7 @@ var _ = Describe("validateAgainstCRQ", func() {
 			},
 		}
 		crqClient = newCRQClient(crq)
-		failing := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
+		failing := func(_ string, _ corev1.ResourceName) (resource.Quantity, error) {
 			return resource.Quantity{}, errors.New("boom")
 		}
 		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
@@ -405,7 +405,7 @@ var _ = Describe("calculateCRQCurrentUsage", func() {
 			},
 		}
 		total, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(context.Context, string, corev1.ResourceName) (resource.Quantity, error) {
+			func(string, corev1.ResourceName) (resource.Quantity, error) {
 				return resource.MustParse("99"), nil
 			}, logger)
 		Expect(err).NotTo(HaveOccurred())
@@ -424,7 +424,7 @@ var _ = Describe("calculateCRQCurrentUsage", func() {
 			},
 		}
 		total, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
+			func(_ string, _ corev1.ResourceName) (resource.Quantity, error) {
 				return resource.MustParse("3"), nil
 			}, logger)
 		Expect(err).NotTo(HaveOccurred())
@@ -442,7 +442,7 @@ var _ = Describe("calculateCRQCurrentUsage", func() {
 			},
 		}
 		_, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(context.Context, string, corev1.ResourceName) (resource.Quantity, error) {
+			func(string, corev1.ResourceName) (resource.Quantity, error) {
 				return resource.Quantity{}, errors.New("calc boom")
 			}, logger)
 		Expect(err).To(HaveOccurred())
@@ -462,7 +462,7 @@ var _ = Describe("calculateCRQCurrentUsage", func() {
 			},
 		}
 		_, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(context.Context, string, corev1.ResourceName) (resource.Quantity, error) {
+			func(string, corev1.ResourceName) (resource.Quantity, error) {
 				return resource.Quantity{}, nil
 			}, logger)
 		Expect(err).To(HaveOccurred())

--- a/pkg/webhook/v1alpha1/webhook_utils.go
+++ b/pkg/webhook/v1alpha1/webhook_utils.go
@@ -1,0 +1,101 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/namespace"
+)
+
+type operation string
+
+const (
+	OperationCreate operation = "creation"
+	OperationUpdate operation = "update"
+	OperationDelete operation = "deletion"
+)
+
+// calculateCRQCurrentUsage sums the per-resource usage across every namespace
+// that matches the CRQ selector. It's the cross-namespace half of
+// validateAgainstCRQ in webhook_handler.go.
+func calculateCRQCurrentUsage(
+	ctx context.Context,
+	kubernetesClient kubernetes.Interface,
+	crq *quotav1alpha1.ClusterResourceQuota,
+	resourceName corev1.ResourceName,
+	calculateCurrentUsage func(string, corev1.ResourceName) (resource.Quantity, error),
+	logger *zap.Logger,
+) (resource.Quantity, error) {
+	namespaceNames, err := namespace.GetSelectedNamespaces(ctx, kubernetesClient, crq)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("failed to get namespaces matching CRQ selector: %w", err)
+	}
+
+	logger.Debug("Calculating usage across CRQ namespaces",
+		zap.String("crq", crq.Name),
+		zap.String("resource", string(resourceName)),
+		zap.Strings("namespaces", namespaceNames))
+
+	totalUsage := resource.NewQuantity(0, resource.DecimalSI)
+	for _, namespaceName := range namespaceNames {
+		nsUsage, err := calculateCurrentUsage(namespaceName, resourceName)
+		if err != nil {
+			logger.Error("Failed to calculate usage for namespace",
+				zap.String("namespace", namespaceName),
+				zap.String("resource", string(resourceName)),
+				zap.Error(err))
+			return resource.Quantity{}, fmt.Errorf("failed to calculate usage for namespace %s: %w", namespaceName, err)
+		}
+		totalUsage.Add(nsUsage)
+
+		logger.Debug("Namespace usage calculated",
+			zap.String("namespace", namespaceName),
+			zap.String("resource", string(resourceName)),
+			zap.String("usage", nsUsage.String()))
+	}
+
+	logger.Debug("Total CRQ usage calculated",
+		zap.String("crq", crq.Name),
+		zap.String("resource", string(resourceName)),
+		zap.String("total_usage", totalUsage.String()),
+		zap.Strings("namespaces", namespaceNames))
+
+	return *totalUsage, nil
+}
+
+// sendWebhookRequest is a test helper that drives the gin engine through an
+// HTTP round-trip and decodes the resulting AdmissionReview.
+func sendWebhookRequest(engine *gin.Engine, admissionReview *admissionv1.AdmissionReview) *admissionv1.AdmissionReview {
+	body, _ := json.Marshal(admissionReview)
+	req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	var response admissionv1.AdmissionReview
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		response = admissionv1.AdmissionReview{
+			Response: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "Failed to parse response",
+				},
+			},
+		}
+	}
+	return &response
+}


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

This pull request updates the PAC Quota Controller Helm chart and webhook logic to improve resource quota enforcement and clarify supported operations. The most significant changes are the restriction of object count validation to only CREATE operations, improved pod resource quota enforcement during pod updates (including resizes), and corresponding updates to webhook configuration and tests.

**Webhook logic and validation improvements:**

* The `ObjectCountWebhook` now only supports CREATE operations, rejecting UPDATE requests with an explicit error. The shared validation logic for create and update was split, and the code now returns an error for unsupported operations. [[1]](diffhunk://#diff-c4e670c94b2ee0ede32cf16c113edd70b30a033751b46049afb3aad8b86a5146R56-R73) [[2]](diffhunk://#diff-c4e670c94b2ee0ede32cf16c113edd70b30a033751b46049afb3aad8b86a5146L89-R82) [[3]](diffhunk://#diff-e57526534ad41ed2b85e11414b1d200d7bd186e95a2e022b7e4cab9ecd880adbR372-R386)
* The `PodWebhook`'s `validatePodOperation` method was refactored to handle both CREATE and UPDATE operations, now correctly calculating and enforcing resource quota deltas during pod resizes (UPDATE on `pods/resize`). The pod-count quota is only charged on CREATE.
* The webhook configuration in `validatingwebhookconfiguration.yaml` was updated to restrict most resources to CREATE-only operations and to support UPDATE only for the `pods/resize` subresource. [[1]](diffhunk://#diff-a9b26c362c56b15733cefc3638de753924983cc482afde8306823f11a1c3fafdL55-R55) [[2]](diffhunk://#diff-a9b26c362c56b15733cefc3638de753924983cc482afde8306823f11a1c3fafdL81-R86) [[3]](diffhunk://#diff-a9b26c362c56b15733cefc3638de753924983cc482afde8306823f11a1c3fafdL159-R179)

**Testing and documentation:**

* Unit tests were added and updated to verify that unsupported operations (e.g., UPDATE for object counts, DELETE for pods) are rejected with the appropriate error messages, and that pod update (resize) requests are handled correctly. [[1]](diffhunk://#diff-e57526534ad41ed2b85e11414b1d200d7bd186e95a2e022b7e4cab9ecd880adbR372-R386) [[2]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64L89-R89) [[3]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64R110-R137) [[4]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64L401-R423) [[5]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64L421-R449)
* The Helm chart version was bumped to 0.4.4 in both `Chart.yaml` and `README.md`, and documentation was updated to reflect the new image tag. [[1]](diffhunk://#diff-346cec95f1bf647a7c17d20653e0188c76de8770a9527a7c36fe666ad23bc6c1L5-R6) [[2]](diffhunk://#diff-3d3a1ac0f55a273a8b76136fefd736eed559a2e74ec6e401babdea7be93b9b20L3-R3) [[3]](diffhunk://#diff-3d3a1ac0f55a273a8b76136fefd736eed559a2e74ec6e401babdea7be93b9b20L74-R74)

## 📚 Documentation

- Helm chart `README.md` regenerated via `make helm-docs`.
- No CRD or values change.

- [x] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
- [x] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [x] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **📝 Note:** Depends on PR #86 (handler refactor) and PR #87 (namespace label). Rebase onto `main` and switch the PR base once those merge.
> **🐙 Note:** For Helm chart installation, use GHCR as an OCI registry. See README for instructions.
