### PR TITLE
refactor(webhook): read CRQ aggregate from status.total.used

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,24 @@ var (
 		},
 		[]string{"webhook", "operation", "decision", "namespace"},
 	)
+	// WebhookCRQLookup counts CRQ resolution outcomes during admission.
+	// Result values: found, not_found, namespace_error, crq_error, no_client.
+	WebhookCRQLookup = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pac_quota_controller_webhook_crq_lookup_total",
+			Help: "Outcome of CRQ resolution attempts during webhook admission.",
+		},
+		[]string{"result"},
+	)
+	// WebhookStatusMissing counts admissions allowed because the CRQ status had
+	// no usage recorded yet for the requested resource (cold start / new key).
+	WebhookStatusMissing = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pac_quota_controller_webhook_status_missing_total",
+			Help: "Number of webhook admissions admitted because the CRQ status had no usage value for the resource.",
+		},
+		[]string{"crq_name", "resource"},
+	)
 
 	// New metrics for controller reconciliation
 	QuotaReconcileTotal = prometheus.NewCounterVec(
@@ -86,6 +104,8 @@ func RegisterWebhookMetrics() {
 			WebhookValidationCount,
 			WebhookValidationDuration,
 			WebhookAdmissionDecision,
+			WebhookCRQLookup,
+			WebhookStatusMissing,
 			QuotaReconcileTotal,
 			QuotaReconcileErrors,
 			QuotaAggregationDuration,

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -164,22 +164,22 @@ func (s *GinWebhookServer) setupRoutes() {
 
 	s.logger.Info("Setting up pod webhook")
 
-	s.podHandler = v1alpha1.NewPodWebhook(s.k8sClient, crqClient, s.logger)
+	s.podHandler = v1alpha1.NewPodWebhook(crqClient, s.logger)
 	s.engine.POST("/validate--v1-pod", s.podHandler.Handle)
 
 	s.logger.Info("Setting up service webhook")
 
-	s.serviceHandler = v1alpha1.NewServiceWebhook(s.k8sClient, crqClient, s.logger)
+	s.serviceHandler = v1alpha1.NewServiceWebhook(crqClient, s.logger)
 	s.engine.POST("/validate--v1-service", s.serviceHandler.Handle)
 
 	s.logger.Info("Setting up PVC webhook")
 
-	s.pvcHandler = v1alpha1.NewPersistentVolumeClaimWebhook(s.k8sClient, crqClient, s.logger)
+	s.pvcHandler = v1alpha1.NewPersistentVolumeClaimWebhook(crqClient, s.logger)
 	s.engine.POST("/validate--v1-persistentvolumeclaim", s.pvcHandler.Handle)
 
 	s.logger.Info("Setting up objectcount webhook")
 
-	s.objectCountHandler = v1alpha1.NewObjectCountWebhook(s.k8sClient, crqClient, s.logger)
+	s.objectCountHandler = v1alpha1.NewObjectCountWebhook(crqClient, s.logger)
 	s.engine.POST("/validate-objectcount-v1", s.objectCountHandler.Handle)
 
 	s.logger.Info("All webhook handlers configured with CRQ client support")

--- a/pkg/webhook/v1alpha1/objectcount_webhook.go
+++ b/pkg/webhook/v1alpha1/objectcount_webhook.go
@@ -7,7 +7,6 @@ import (
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
 )
@@ -76,7 +75,7 @@ func (h *ObjectCountWebhook) validateOperation(
 	}
 	if err := validateAgainstCRQ(
 		ctx, h.crqClient, h.logger,
-		namespace, resourceName, resource.MustParse("1"),
+		namespace, resourceName, oneQuantity,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/v1alpha1/objectcount_webhook.go
+++ b/pkg/webhook/v1alpha1/objectcount_webhook.go
@@ -8,24 +8,19 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/client-go/kubernetes"
 
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/objectcount"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
 )
 
 // ObjectCountWebhook handles webhook requests for Object count resources.
 // It enforces object count quotas for objects and subtypes.
 type ObjectCountWebhook struct {
-	client                kubernetes.Interface
-	objectCountCalculator *objectcount.ObjectCountCalculator
-	crqClient             *quota.CRQClient
-	logger                *zap.Logger
+	crqClient *quota.CRQClient
+	logger    *zap.Logger
 }
 
 // NewObjectCountWebhook creates a new ObjectCountWebhook
 func NewObjectCountWebhook(
-	k8sClient kubernetes.Interface,
 	crqClient *quota.CRQClient,
 	logger *zap.Logger,
 ) *ObjectCountWebhook {
@@ -34,10 +29,8 @@ func NewObjectCountWebhook(
 	}
 	logger = logger.Named("objectcount-webhook")
 	return &ObjectCountWebhook{
-		client:                k8sClient,
-		objectCountCalculator: objectcount.NewObjectCountCalculator(k8sClient, logger),
-		crqClient:             crqClient,
-		logger:                logger,
+		crqClient: crqClient,
+		logger:    logger,
 	}
 }
 
@@ -53,9 +46,6 @@ func (h *ObjectCountWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *ObjectCountWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
 	// Chart only subscribes vobjectcount to CREATE since object counts cannot
 	// change on UPDATE; this guard is a defensive seatbelt in case the chart
@@ -85,8 +75,8 @@ func (h *ObjectCountWebhook) validateOperation(
 		return nil, nil
 	}
 	if err := validateAgainstCRQ(
-		ctx, h.client, h.crqClient, h.logger,
-		namespace, resourceName, resource.MustParse("1"), h.objectCountCalculator.CalculateUsage,
+		ctx, h.crqClient, h.logger,
+		namespace, resourceName, resource.MustParse("1"),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/v1alpha1/objectcount_webhook_test.go
+++ b/pkg/webhook/v1alpha1/objectcount_webhook_test.go
@@ -1,400 +1,180 @@
 package v1alpha1
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"net/http/httptest"
-
 	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/fake"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
-	pkglogger "github.com/powerhome/pac-quota-controller/pkg/logger"
 )
 
-var _ = Describe("ObjectCountWebhook", func() {
-	var (
-		webhook    *ObjectCountWebhook
-		fakeClient *fake.Clientset
-		crqClient  *quota.CRQClient
-		logger     *zap.Logger
-		ginEngine  *gin.Engine
-		scheme     *runtime.Scheme
-		nsName     string
-	)
-
-	BeforeEach(func() {
-		scheme = runtime.NewScheme()
-		_ = quotav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		_ = appsv1.AddToScheme(scheme)
-		fakeClient = fake.NewSimpleClientset()
-		logger = pkglogger.L()
-		gin.SetMode(gin.TestMode)
-		ginEngine = gin.New()
-		nsName = "test-namespace"
-	})
-
-	AfterEach(func() {
-		// No-op for now, but can be used for cleanup
-	})
-
-	Describe("NewObjectCountWebhook", func() {
-		It("should create a new object count webhook", func() {
-			fakeClient = fake.NewSimpleClientset()
-			crqClient = quota.NewCRQClient(nil, logger)
-			webhook = NewObjectCountWebhook(fakeClient, crqClient, logger)
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(Equal(fakeClient))
-			Expect(webhook.logger).NotTo(BeNil())
-			Expect(webhook.crqClient).To(Equal(crqClient))
-		})
-
-		It("should create webhook with nil client", func() {
-			crqClient = quota.NewCRQClient(nil, logger)
-			webhook = NewObjectCountWebhook(nil, crqClient, logger)
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(BeNil())
-		})
-
-		It("should create webhook with nil logger", func() {
-			fakeClient = fake.NewSimpleClientset()
-			crqClient = quota.NewCRQClient(nil, logger)
-			webhook = NewObjectCountWebhook(fakeClient, crqClient, nil)
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.logger).NotTo(BeNil())
-		})
-
-		It("should create webhook with nil CRQ client", func() {
-			fakeClient = fake.NewSimpleClientset()
-			webhook = NewObjectCountWebhook(fakeClient, nil, logger)
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.crqClient).To(BeNil())
-		})
-
-		It("should create webhook with all nil parameters", func() {
-			webhook = NewObjectCountWebhook(nil, nil, nil)
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(BeNil())
-			Expect(webhook.crqClient).To(BeNil())
-			Expect(webhook.logger).NotTo(BeNil())
-		})
-	})
-
-	Describe("Handle AdmissionRequest", func() {
-		Context("with CRQ and configmaps", func() {
-			BeforeEach(func() {
-				crq := &quotav1alpha1.ClusterResourceQuota{
-					ObjectMeta: metav1.ObjectMeta{Name: "crq"},
-					Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "test"}},
-						Hard: quotav1alpha1.ResourceList{
-							"configmaps":                           resource.MustParse("2"),
-							"secrets":                              resource.MustParse("1"),
-							"replicationcontrollers":               resource.MustParse("1"),
-							"deployments.apps":                     resource.MustParse("1"),
-							"statefulsets.apps":                    resource.MustParse("1"),
-							"daemonsets.apps":                      resource.MustParse("1"),
-							"jobs.batch":                           resource.MustParse("1"),
-							"cronjobs.batch":                       resource.MustParse("1"),
-							"horizontalpodautoscalers.autoscaling": resource.MustParse("1"),
-							"ingresses.networking.k8s.io":          resource.MustParse("1"),
-						},
-					},
-				}
-				ns := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{Name: nsName, Labels: map[string]string{"env": "test"}},
-				}
-				_, _ = fakeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-				fakeRuntimeClient := ctrlclientfake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(crq, ns).Build()
-				crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-				webhook = NewObjectCountWebhook(fakeClient, crqClient, logger)
-				ginEngine.POST("/webhook", webhook.Handle)
-			})
-
-			It("should allow creation when under quota", func() {
-				_, _ = fakeClient.CoreV1().ConfigMaps(nsName).Create(
-					context.Background(),
-					&corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "cm1",
-							Namespace: nsName,
-						},
-					},
-					metav1.CreateOptions{},
-				)
-				review := createObjectCountAdmissionReview("123", nsName, "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeTrue())
-			})
-
-			It("should deny creation when quota exceeded", func() {
-				// Add 2 configmaps to reach quota
-				_, err := fakeClient.CoreV1().ConfigMaps(nsName).Create(
-					context.Background(),
-					&corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "cm1",
-							Namespace: nsName,
-						},
-					}, metav1.CreateOptions{},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				_, err = fakeClient.CoreV1().ConfigMaps(nsName).Create(
-					context.Background(),
-					&corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "cm2",
-							Namespace: nsName,
-						},
-					},
-					metav1.CreateOptions{},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				review := createObjectCountAdmissionReview("456", nsName, "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeFalse())
-				Expect(resp.Response.Result.Message).To(ContainSubstring("ClusterResourceQuota"))
-				Expect(resp.Response.Result.Message).To(ContainSubstring("configmaps limit exceeded"))
-			})
-
-			It("should allow creation with multiple objects under quota", func() {
-				// Add 1 configmap, quota is 2
-				cm := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cm1",
-						Namespace: nsName,
-					},
-				}
-				_, err := fakeClient.CoreV1().ConfigMaps(nsName).Create(
-					context.Background(),
-					cm,
-					metav1.CreateOptions{},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				// Simulate batch creation (not strictly supported by AdmissionReview, but test logic)
-				review := createObjectCountAdmissionReview("789", nsName, "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeTrue())
-			})
-
-			It("should allow creation of one deployment", func() {
-				review := createObjectCountAdmissionReview("2001", nsName, "deployments.apps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeTrue())
-			})
-
-			It("should deny creation of two deployments", func() {
-				// Create one existing deployment
-				dep, err := webhook.client.AppsV1().Deployments(nsName).Create(context.Background(), &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: "dep1", Namespace: nsName},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "myapp"},
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{"app": "myapp"},
-							},
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "minimal",
-										Image: "busybox",
-									},
-								},
-							},
-						},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(dep).NotTo(BeNil())
-				Expect(dep).NotTo(BeNil())
-				review := createObjectCountAdmissionReview("2002", nsName, "deployments.apps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeFalse())
-				Expect(resp.Response.Result.Message).To(ContainSubstring("ClusterResourceQuota"))
-				Expect(resp.Response.Result.Message).To(ContainSubstring("deployments.apps limit exceeded"))
-			})
-
-			It("should allow creation of one deployment and one ingress", func() {
-				reviewDep := createObjectCountAdmissionReview("2003", nsName, "deployments.apps")
-				bodyDep, _ := json.Marshal(reviewDep)
-				reqDep := httptest.NewRequest("POST", "/webhook", bytes.NewReader(bodyDep))
-				wDep := httptest.NewRecorder()
-				ginEngine.ServeHTTP(wDep, reqDep)
-				Expect(wDep.Code).To(Equal(200))
-				var respDep admissionv1.AdmissionReview
-				_ = json.Unmarshal(wDep.Body.Bytes(), &respDep)
-				Expect(respDep.Response.Allowed).To(BeTrue())
-
-				reviewIng := createObjectCountAdmissionReview("2004", nsName, "ingresses.networking.k8s.io")
-				bodyIng, _ := json.Marshal(reviewIng)
-				reqIng := httptest.NewRequest("POST", "/webhook", bytes.NewReader(bodyIng))
-				wIng := httptest.NewRecorder()
-				ginEngine.ServeHTTP(wIng, reqIng)
-				Expect(wIng.Code).To(Equal(200))
-				var respIng admissionv1.AdmissionReview
-				_ = json.Unmarshal(wIng.Body.Bytes(), &respIng)
-				Expect(respIng.Response.Allowed).To(BeTrue())
-			})
-
-			It("should deny creation with multiple objects over quota", func() {
-				// Add 2 configmaps, quota is 2
-				// Add 2 configmaps, quota is 2
-				cm1 := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cm1",
-						Namespace: nsName,
-					},
-				}
-				cm2 := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cm2",
-						Namespace: nsName,
-					},
-				}
-				_, err := fakeClient.CoreV1().ConfigMaps(nsName).Create(
-					context.Background(), cm1, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				_, err = fakeClient.CoreV1().ConfigMaps(nsName).Create(
-					context.Background(), cm2, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				review := createObjectCountAdmissionReview("1011", nsName, "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeFalse())
-				Expect(resp.Response.Result.Message).To(ContainSubstring("ClusterResourceQuota"))
-				Expect(resp.Response.Result.Message).To(ContainSubstring("configmaps limit exceeded"))
-			})
-
-			It("should allow creation with zero objects", func() {
-				// No configmaps present
-				review := createObjectCountAdmissionReview("1213", nsName, "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeTrue())
-			})
-
-			It("should allow creation of unknown resource type", func() {
-				review := createObjectCountAdmissionReview("1415", nsName, "invalidresource")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeTrue())
-			})
-
-			It("should deny creation when namespace missing", func() {
-				review := createObjectCountAdmissionReview("1617", "", "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeFalse())
-				Expect(resp.Response.Result.Message).To(ContainSubstring("Namespace is required for objectcount validation"))
-			})
-
-			It("should allow creation when CRQClient fails", func() {
-				// Simulate CRQClient failure by passing nil client
-				webhook.crqClient = quota.NewCRQClient(nil, logger)
-				review := createObjectCountAdmissionReview("1819", nsName, "configmaps")
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeTrue())
-			})
-
-			It("should reject UPDATE with unsupportedOperationError", func() {
-				review := createObjectCountAdmissionReview("2020", nsName, "configmaps")
-				review.Request.Operation = admissionv1.Update
-				body, _ := json.Marshal(review)
-				req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
-				w := httptest.NewRecorder()
-				ginEngine.ServeHTTP(w, req)
-				Expect(w.Code).To(Equal(200))
-				var resp admissionv1.AdmissionReview
-				_ = json.Unmarshal(w.Body.Bytes(), &resp)
-				Expect(resp.Response.Allowed).To(BeFalse())
-				Expect(resp.Response.Result.Code).To(Equal(int32(400)))
-				Expect(resp.Response.Result.Message).To(ContainSubstring("Operation UPDATE is not supported for ObjectCount"))
-			})
-		})
-	})
-})
-
-func createObjectCountAdmissionReview(uid, namespace, resourceName string) admissionv1.AdmissionReview {
-	return admissionv1.AdmissionReview{
+func newObjectCountReview(uid, namespace, resource, group string) *admissionv1.AdmissionReview {
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
 		Request: &admissionv1.AdmissionRequest{
 			UID:       types.UID(uid),
 			Namespace: namespace,
 			Operation: admissionv1.Create,
-			Resource:  metav1.GroupVersionResource{Resource: resourceName},
+			Resource:  metav1.GroupVersionResource{Resource: resource, Group: group},
 		},
 	}
 }
+
+var _ = Describe("ObjectCountWebhook", func() {
+	const (
+		nsName  = "test-namespace"
+		crqName = "objcount-crq"
+	)
+	var (
+		engine *gin.Engine
+		labels = map[string]string{"env": "test"}
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		engine = gin.New()
+	})
+
+	Describe("NewObjectCountWebhook", func() {
+		It("constructs with all dependencies", func() {
+			client := newTestCRQClient()
+			h := NewObjectCountWebhook(client, zap.NewNop())
+			Expect(h).NotTo(BeNil())
+			Expect(h.crqClient).To(Equal(client))
+		})
+
+		It("substitutes a no-op logger when nil is passed", func() {
+			h := NewObjectCountWebhook(nil, nil)
+			Expect(h).NotTo(BeNil())
+			Expect(h.logger).NotTo(BeNil())
+		})
+	})
+
+	Describe("Handle (status-read path)", func() {
+		It("admits configmap creation when under the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{"configmaps": quantity("5")},
+				quotav1alpha1.ResourceList{"configmaps": quantity("2")},
+			)
+			h := NewObjectCountWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("1", nsName, "configmaps", ""))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies configmap creation when at the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{"configmaps": quantity("2")},
+				quotav1alpha1.ResourceList{"configmaps": quantity("2")},
+			)
+			h := NewObjectCountWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("2", nsName, "configmaps", ""))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("configmaps limit exceeded"))
+		})
+
+		It("uses '<resource>.<group>' as the CRQ key", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{"deployments.apps": quantity("1")},
+				quotav1alpha1.ResourceList{"deployments.apps": quantity("1")},
+			)
+			h := NewObjectCountWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("3", nsName, "deployments", "apps"))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("deployments.apps limit exceeded"))
+		})
+
+		It("admits when the resource is not in the CRQ hard map", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{"configmaps": quantity("1")},
+				quotav1alpha1.ResourceList{"configmaps": quantity("0")},
+			)
+			h := NewObjectCountWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("4", nsName, "secrets", ""))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("admits when no CRQ matches the namespace", func() {
+			ns := makeNamespace(nsName, labels)
+			h := NewObjectCountWebhook(newTestCRQClient(ns), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("5", nsName, "configmaps", ""))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("admits when the CRQ client is nil", func() {
+			h := NewObjectCountWebhook(nil, zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("6", nsName, "configmaps", ""))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies when namespace is empty", func() {
+			h := NewObjectCountWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("7", "", "configmaps", ""))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Namespace is required"))
+		})
+
+		It("admits DELETE operation as unsupported (returns 400)", func() {
+			h := NewObjectCountWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newObjectCountReview("8", nsName, "configmaps", "")
+			review.Request.Operation = admissionv1.Delete
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("not supported for ObjectCount"))
+		})
+
+		It("rejects UPDATE as unsupported (defensive seatbelt: chart only subscribes to CREATE)", func() {
+			h := NewObjectCountWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newObjectCountReview("8u", nsName, "configmaps", "")
+			review.Request.Operation = admissionv1.Update
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Code).To(Equal(int32(400)))
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Operation UPDATE is not supported for ObjectCount"))
+		})
+
+		It("admits (fail-open) when CRQ status is missing usage for the resource", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{"configmaps": quantity("2")},
+				nil,
+			)
+			// Force compile-time use of corev1 import.
+			_ = corev1.ResourceCPU
+			h := NewObjectCountWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newObjectCountReview("9", nsName, "configmaps", ""))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+	})
+})

--- a/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook.go
+++ b/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -11,24 +10,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/storage"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
 )
 
 // PersistentVolumeClaimWebhook handles webhook requests for PersistentVolumeClaim resources
 type PersistentVolumeClaimWebhook struct {
-	client            kubernetes.Interface
-	storageCalculator storage.StorageResourceCalculator
-	crqClient         *quota.CRQClient
-	logger            *zap.Logger
+	crqClient *quota.CRQClient
+	logger    *zap.Logger
 }
 
 // NewPersistentVolumeClaimWebhook creates a new PersistentVolumeClaimWebhook
 func NewPersistentVolumeClaimWebhook(
-	k8sClient kubernetes.Interface,
 	crqClient *quota.CRQClient,
 	logger *zap.Logger,
 ) *PersistentVolumeClaimWebhook {
@@ -37,10 +31,8 @@ func NewPersistentVolumeClaimWebhook(
 	}
 	logger = logger.Named("pvc-webhook")
 	return &PersistentVolumeClaimWebhook{
-		client:            k8sClient,
-		storageCalculator: *storage.NewStorageResourceCalculator(k8sClient, logger),
-		crqClient:         crqClient,
-		logger:            logger,
+		crqClient: crqClient,
+		logger:    logger,
 	}
 }
 
@@ -53,9 +45,6 @@ func (h *PersistentVolumeClaimWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *PersistentVolumeClaimWebhook) validate(
 	ctx context.Context,
 	req *admissionv1.AdmissionRequest,
@@ -78,49 +67,45 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 	ctx context.Context,
 	pvc *corev1.PersistentVolumeClaim,
 ) error {
-	storageRequest := getStorageRequest(pvc)
-
-	if err := validateAgainstCRQ(
-		ctx, h.client, h.crqClient, h.logger,
-		pvc.Namespace, usage.ResourceRequestsStorage, storageRequest, h.calculateCurrentUsage,
-	); err != nil {
-		return fmt.Errorf("ClusterResourceQuota storage validation failed: %w", err)
+	crq := resolveCRQForNamespace(ctx, h.crqClient, h.logger, pvc.Namespace)
+	if crq == nil {
+		return nil
 	}
 
-	pvcCount := resource.NewQuantity(1, resource.DecimalSI)
-	if err := validateAgainstCRQ(
-		ctx, h.client, h.crqClient, h.logger,
-		pvc.Namespace, usage.ResourcePersistentVolumeClaims, *pvcCount, h.calculateCurrentUsage,
-	); err != nil {
-		return fmt.Errorf("ClusterResourceQuota PVC count validation failed: %w", err)
+	correlationID := quota.GetCorrelationID(ctx)
+	storageRequest := getStorageRequest(pvc)
+	pvcCount := *resource.NewQuantity(1, resource.DecimalSI)
+
+	type check struct {
+		resource corev1.ResourceName
+		quantity resource.Quantity
+		errFmt   string
+	}
+	checks := []check{
+		{usage.ResourceRequestsStorage, storageRequest, "ClusterResourceQuota storage validation failed: %w"},
+		{usage.ResourcePersistentVolumeClaims, pvcCount, "ClusterResourceQuota PVC count validation failed: %w"},
 	}
 
 	if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
 		storageClass := *pvc.Spec.StorageClassName
+		checks = append(checks,
+			check{
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.storage", storageClass)),
+				storageRequest,
+				fmt.Sprintf("ClusterResourceQuota storage class '%s' storage validation failed: %%w", storageClass),
+			},
+			check{
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClass)),
+				pvcCount,
+				fmt.Sprintf("ClusterResourceQuota storage class '%s' PVC count validation failed: %%w", storageClass),
+			},
+		)
+	}
 
-		storageClassStorageResource := corev1.ResourceName(fmt.Sprintf(
-			"%s.storageclass.storage.k8s.io/requests.storage", storageClass))
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			pvc.Namespace, storageClassStorageResource, storageRequest, h.calculateCurrentUsage,
-		); err != nil {
-			return fmt.Errorf("ClusterResourceQuota storage class '%s' storage validation failed: %w", storageClass, err)
+	for _, c := range checks {
+		if err := validateCRQStatusUsage(crq, c.resource, c.quantity, h.logger, correlationID); err != nil {
+			return fmt.Errorf(c.errFmt, err)
 		}
-
-		storageClassCountResource := corev1.ResourceName(fmt.Sprintf(
-			"%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClass))
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			pvc.Namespace, storageClassCountResource, *pvcCount, h.calculateCurrentUsage,
-		); err != nil {
-			return fmt.Errorf("ClusterResourceQuota storage class '%s' PVC count validation failed: %w", storageClass, err)
-		}
-
-		h.logger.Debug("PVC storage class specific CRQ validation passed",
-			zap.String("pvc", pvc.Name),
-			zap.String("namespace", pvc.Namespace),
-			zap.String("storageClass", storageClass),
-			zap.String("storageRequest", storageRequest.String()))
 	}
 
 	h.logger.Debug("PVC CRQ validation passed",
@@ -128,36 +113,6 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 		zap.String("namespace", pvc.Namespace),
 		zap.String("storageRequest", storageRequest.String()))
 	return nil
-}
-
-// calculateCurrentUsage calculates the current usage of a resource in a namespace
-func (h *PersistentVolumeClaimWebhook) calculateCurrentUsage(ctx context.Context, namespace string,
-	resourceName corev1.ResourceName) (resource.Quantity, error) {
-	switch resourceName {
-	case usage.ResourceRequestsStorage:
-		return h.storageCalculator.CalculateUsage(ctx, namespace, resourceName)
-	case usage.ResourcePersistentVolumeClaims:
-		count, err := h.storageCalculator.CalculatePVCCount(ctx, namespace)
-		if err != nil {
-			return resource.Quantity{}, err
-		}
-		return *resource.NewQuantity(count, resource.DecimalSI), nil
-	default:
-		resourceStr := string(resourceName)
-		if strings.HasSuffix(resourceStr, ".storageclass.storage.k8s.io/requests.storage") {
-			storageClass := strings.TrimSuffix(resourceStr, ".storageclass.storage.k8s.io/requests.storage")
-			return h.storageCalculator.CalculateStorageClassUsage(ctx, namespace, storageClass)
-		}
-		if strings.HasSuffix(resourceStr, ".storageclass.storage.k8s.io/persistentvolumeclaims") {
-			storageClass := strings.TrimSuffix(resourceStr, ".storageclass.storage.k8s.io/persistentvolumeclaims")
-			count, err := h.storageCalculator.CalculateStorageClassCount(ctx, namespace, storageClass)
-			if err != nil {
-				return resource.Quantity{}, err
-			}
-			return *resource.NewQuantity(count, resource.DecimalSI), nil
-		}
-		return resource.Quantity{}, fmt.Errorf("unsupported resource type: %s", resourceName)
-	}
 }
 
 func getStorageRequest(pvc *corev1.PersistentVolumeClaim) resource.Quantity {

--- a/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook.go
+++ b/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook.go
@@ -45,6 +45,9 @@ func (h *PersistentVolumeClaimWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
+// TODO: the []string return is a future-proofing placeholder for admission
+// warnings. Once any validator actually emits warnings, plumb them through
+// runWebhook into AdmissionResponse.Warnings.
 func (h *PersistentVolumeClaimWebhook) validate(
 	ctx context.Context,
 	req *admissionv1.AdmissionRequest,
@@ -60,12 +63,22 @@ func (h *PersistentVolumeClaimWebhook) validate(
 		return nil, err
 	}
 
-	return nil, h.validateOperation(ctx, &pvc)
+	var oldPVC *corev1.PersistentVolumeClaim
+	if req.Operation == admissionv1.Update && len(req.OldObject.Raw) > 0 {
+		var p corev1.PersistentVolumeClaim
+		if err := decodeAdmissionObject(req.OldObject.Raw, &p, "PersistentVolumeClaim"); err != nil {
+			return nil, err
+		}
+		oldPVC = &p
+	}
+
+	return nil, h.validateOperation(ctx, &pvc, oldPVC)
 }
 
 func (h *PersistentVolumeClaimWebhook) validateOperation(
 	ctx context.Context,
 	pvc *corev1.PersistentVolumeClaim,
+	oldPVC *corev1.PersistentVolumeClaim,
 ) error {
 	crq := resolveCRQForNamespace(ctx, h.crqClient, h.logger, pvc.Namespace)
 	if crq == nil {
@@ -73,8 +86,10 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 	}
 
 	correlationID := quota.GetCorrelationID(ctx)
-	storageRequest := getStorageRequest(pvc)
-	pvcCount := *resource.NewQuantity(1, resource.DecimalSI)
+	storageDelta := getStorageRequest(pvc)
+	if oldPVC != nil {
+		storageDelta.Sub(getStorageRequest(oldPVC))
+	}
 
 	type check struct {
 		resource corev1.ResourceName
@@ -82,27 +97,39 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 		errFmt   string
 	}
 	checks := []check{
-		{usage.ResourceRequestsStorage, storageRequest, "ClusterResourceQuota storage validation failed: %w"},
-		{usage.ResourcePersistentVolumeClaims, pvcCount, "ClusterResourceQuota PVC count validation failed: %w"},
+		{usage.ResourceRequestsStorage, storageDelta, "ClusterResourceQuota storage validation failed: %w"},
 	}
-
 	if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
 		storageClass := *pvc.Spec.StorageClassName
-		checks = append(checks,
-			check{
-				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.storage", storageClass)),
-				storageRequest,
-				fmt.Sprintf("ClusterResourceQuota storage class '%s' storage validation failed: %%w", storageClass),
-			},
-			check{
+		checks = append(checks, check{
+			corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.storage", storageClass)),
+			storageDelta,
+			fmt.Sprintf("ClusterResourceQuota storage class '%s' storage validation failed: %%w", storageClass),
+		})
+	}
+	// Count checks only apply on Create; Update never adds or removes a PVC.
+	if oldPVC == nil {
+		checks = append(checks, check{
+			usage.ResourcePersistentVolumeClaims, oneQuantity,
+			"ClusterResourceQuota PVC count validation failed: %w",
+		})
+		if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
+			storageClass := *pvc.Spec.StorageClassName
+			checks = append(checks, check{
 				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClass)),
-				pvcCount,
+				oneQuantity,
 				fmt.Sprintf("ClusterResourceQuota storage class '%s' PVC count validation failed: %%w", storageClass),
-			},
-		)
+			})
+		}
 	}
 
 	for _, c := range checks {
+		// Weird edge-case where an admission request for PVC downsizing passes from the API
+		// This should not happen, but helps the tests, as we can't assume answers from the API
+		// Potentially dead code
+		if c.quantity.Sign() <= 0 {
+			continue
+		}
 		if err := validateCRQStatusUsage(crq, c.resource, c.quantity, h.logger, correlationID); err != nil {
 			return fmt.Errorf(c.errFmt, err)
 		}
@@ -111,7 +138,7 @@ func (h *PersistentVolumeClaimWebhook) validateOperation(
 	h.logger.Debug("PVC CRQ validation passed",
 		zap.String("pvc", pvc.Name),
 		zap.String("namespace", pvc.Namespace),
-		zap.String("storageRequest", storageRequest.String()))
+		zap.String("storageDelta", storageDelta.String()))
 	return nil
 }
 

--- a/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook_test.go
+++ b/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook_test.go
@@ -1,993 +1,214 @@
 package v1alpha1
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/apimachinery/pkg/types"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
-	pkglogger "github.com/powerhome/pac-quota-controller/pkg/logger"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-const (
-	premiumSSDStorageClass          = "premium-ssd"
-	fastSSDStorageClassResourceName = "fast-ssd.storageclass.storage.k8s.io/persistentvolumeclaims"
-)
-
-var _ = Describe("PersistentVolumeClaimWebhook", func() {
-	var (
-		ctx               context.Context
-		ginEngine         *gin.Engine
-		webhook           *PersistentVolumeClaimWebhook
-		fakeRuntimeClient client.Client
-		k8sClient         kubernetes.Interface
-		crqClient         *quota.CRQClient
-		testNamespace     *corev1.Namespace
-		logger            *zap.Logger
-	)
-
-	BeforeEach(func() {
-		gin.SetMode(gin.TestMode)
-		ginEngine = gin.New()
-
-		// Create test namespace that will be used in tests
-		testNamespace = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-namespace",
-			},
-		}
-
-		// Create webhook with fake client
-		k8sClient = fake.NewSimpleClientset(testNamespace)
-		scheme := runtime.NewScheme()
-		logger = pkglogger.L()
-		_ = quotav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		fakeRuntimeClient = ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
-		crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-		webhook = NewPersistentVolumeClaimWebhook(k8sClient, crqClient, logger)
-
-		// Setup route
-		ginEngine.POST("/pvc", webhook.Handle)
-	})
-
-	Describe("NewPersistentVolumeClaimWebhook", func() {
-		It("should create a new webhook instance", func() {
-			webhook := NewPersistentVolumeClaimWebhook(k8sClient, crqClient, logger)
-
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(Equal(k8sClient))
-			Expect(webhook.logger).NotTo(BeNil())
-			Expect(webhook.storageCalculator).NotTo(BeNil())
-		})
-
-		It("should create webhook with nil client", func() {
-			webhook := NewPersistentVolumeClaimWebhook(nil, crqClient, logger)
-
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(BeNil())
-			Expect(webhook.logger).NotTo(BeNil())
-		})
-
-		It("should create webhook with nil logger", func() {
-			webhook := NewPersistentVolumeClaimWebhook(k8sClient, crqClient, nil)
-
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(Equal(k8sClient))
-			Expect(webhook.logger).NotTo(BeNil())
-		})
-
-		It("should create webhook with nil CRQ client", func() {
-			webhook := NewPersistentVolumeClaimWebhook(k8sClient, nil, logger)
-
-			Expect(webhook).NotTo(BeNil())
-			Expect(webhook.client).To(Equal(k8sClient))
-			Expect(webhook.crqClient).To(BeNil())
-		})
-	})
-
-	Describe("Handle", func() {
-		It("should handle PVC creation successfully", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"),
-						},
-					},
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(pvc, admissionv1.Create)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeTrue())
-		})
-
-		It("should handle PVC update successfully", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("2Gi"),
-						},
-					},
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(pvc, admissionv1.Update)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeTrue())
-		})
-
-		It("should handle PVC with no storage request", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{},
-					},
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(pvc, admissionv1.Create)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeTrue())
-		})
-
-		It("should reject request with wrong resource kind", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(pvc, admissionv1.Create)
-			admissionReview.Request.Kind = metav1.GroupVersionKind{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
-			}
-
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeFalse())
-			Expect(response.Result.Message).To(ContainSubstring("Expected PersistentVolumeClaim resource"))
-		})
-
-		It("should handle unsupported operations", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(pvc, admissionv1.Delete)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeFalse())
-			Expect(response.Result.Message).To(ContainSubstring("Operation DELETE is not supported"))
-		})
-
-		It("should handle nil admission review request", func() {
-			// Create a request with nil Request field
-			admissionReview := admissionv1.AdmissionReview{
-				Request: nil,
-				Response: &admissionv1.AdmissionResponse{
-					UID: "test-uid",
-				},
-			}
-
-			// Send the request directly to avoid the helper function
-			body, err := json.Marshal(admissionReview)
-			Expect(err).NotTo(HaveOccurred())
-
-			req, _ := http.NewRequest("POST", "/pvc", bytes.NewBuffer(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("should handle invalid JSON", func() {
-			req, _ := http.NewRequest("POST", "/pvc", bytes.NewBufferString("invalid json"))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-	})
-
-	Describe("validateCreate", func() {
-		It("should validate PVC creation successfully", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"),
-						},
-					},
-				},
-			}
-
-			err := webhook.validateOperation(ctx, pvc)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Describe("validateUpdate", func() {
-		It("should validate PVC update successfully", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("2Gi"),
-						},
-					},
-				},
-			}
-
-			err := webhook.validateOperation(ctx, pvc)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Describe("validateOperation", func() {
-		It("should validate storage quota successfully", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"),
-						},
-					},
-				},
-			}
-
-			err := webhook.validateOperation(ctx, pvc)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should handle PVC with no storage request", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: testNamespace.Name,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{},
-					},
-				},
-			}
-
-			err := webhook.validateOperation(ctx, pvc)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Describe("validateAgainstCRQ", func() {
-		It("should validate storage quota successfully when within limits", func() {
-			err := validateAgainstCRQ(ctx, webhook.client, webhook.crqClient, webhook.logger,
-				testNamespace.Name, corev1.ResourceStorage, resource.MustParse("1Gi"),
-				webhook.calculateCurrentUsage)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should handle namespace not found", func() {
-			err := validateAgainstCRQ(ctx, webhook.client, webhook.crqClient, webhook.logger,
-				"nonexistent-namespace", corev1.ResourceStorage, resource.MustParse("1Gi"),
-				webhook.calculateCurrentUsage)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("namespaces \"nonexistent-namespace\" not found"))
-		})
-	})
-
-	Describe("Cross-Namespace Storage Validation", func() {
-		var (
-			crq         *quotav1alpha1.ClusterResourceQuota
-			namespace1  *corev1.Namespace
-			namespace2  *corev1.Namespace
-			existingPVC *corev1.PersistentVolumeClaim
-		)
-
-		BeforeEach(func() {
-			// Create test namespaces with matching labels
-			namespace1 = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-ns-1",
-					Labels: map[string]string{
-						"storage-test": "enabled",
-					},
-				},
-			}
-			namespace2 = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-ns-2",
-					Labels: map[string]string{
-						"storage-test": "enabled",
-					},
-				},
-			}
-
-			// Create a ClusterResourceQuota for storage
-			crq = &quotav1alpha1.ClusterResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-crq",
-				},
-				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"storage-test": "enabled",
-						},
-					},
-					Hard: quotav1alpha1.ResourceList{
-						corev1.ResourceRequestsStorage:        resource.MustParse("10Gi"),
-						corev1.ResourcePersistentVolumeClaims: resource.MustParse("5"),
-					},
-				},
-			}
-
-			// Create an existing PVC in namespace1
-			existingPVC = &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "existing-pvc",
-					Namespace: "storage-ns-1",
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("8Gi"),
-						},
-					},
-				},
-			}
-
-			// Update clients with cross-namespace resources
-			k8sClient := fake.NewSimpleClientset(testNamespace, namespace1, namespace2, existingPVC)
-			scheme := runtime.NewScheme()
-			_ = quotav1alpha1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
-			fakeRuntimeClient = ctrlclientfake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(crq, namespace1, namespace2).
-				Build()
-			crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-			webhook = NewPersistentVolumeClaimWebhook(k8sClient, crqClient, logger)
-
-			// Re-setup gin engine
-			ginEngine = gin.New()
-			ginEngine.POST("/pvc", webhook.Handle)
-		})
-
-		AfterEach(func() {
-			// Clean up cross-namespace test resources
-			crq = nil
-			namespace1 = nil
-			namespace2 = nil
-			existingPVC = nil
-		})
-
-		It("should reject PVC that would exceed cross-namespace storage quota", func() {
-			// Try to create a PVC in namespace2 that would exceed the total storage quota
-			newPVC := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-pvc",
-					Namespace: "storage-ns-2",
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("5Gi"), // 8Gi + 5Gi = 13Gi > 10Gi limit
-						},
-					},
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(newPVC, admissionv1.Create)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeFalse())
-			Expect(response.Result.Message).To(ContainSubstring("storage-crq"))
-			Expect(response.Result.Message).To(ContainSubstring("limit exceeded"))
-		})
-
-		It("should allow PVC within cross-namespace storage quota", func() {
-			// Try to create a PVC in namespace2 that fits within the quota
-			newPVC := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "small-pvc",
-					Namespace: "storage-ns-2",
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"), // 8Gi + 1Gi = 9Gi < 10Gi limit
-						},
-					},
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(newPVC, admissionv1.Create)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeTrue())
-		})
-
-		It("should allow PVC in namespace not matching CRQ selector", func() {
-			// Create a namespace that doesn't match the CRQ selector
-			unmatchedNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "unmatched-storage-ns",
-					Labels: map[string]string{
-						"storage-test": "disabled",
-					},
-				},
-			}
-
-			// Update client
-			k8sClient := fake.NewSimpleClientset(testNamespace, namespace1, namespace2, existingPVC, unmatchedNamespace)
-			webhook = NewPersistentVolumeClaimWebhook(k8sClient, crqClient, logger)
-			ginEngine = gin.New()
-			ginEngine.POST("/pvc", webhook.Handle)
-
-			// Try to create a large PVC in the unmatched namespace
-			newPVC := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "unmatched-pvc",
-					Namespace: "unmatched-storage-ns",
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("100Gi"), // Large request, but no CRQ applies
-						},
-					},
-				},
-			}
-
-			admissionReview := createPVCAdmissionReview(newPVC, admissionv1.Create)
-			response := sendPVCWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Allowed).To(BeTrue())
-		})
-	})
-
-	Describe("getStorageRequest", func() {
-		It("should extract storage request from PVC", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"),
-						},
-					},
-				},
-			}
-
-			storageRequest := getStorageRequest(pvc)
-			Expect(storageRequest).To(Equal(resource.MustParse("1Gi")))
-		})
-
-		It("should return empty quantity when no storage request", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{},
-					},
-				},
-			}
-
-			storageRequest := getStorageRequest(pvc)
-			Expect(storageRequest).To(Equal(resource.Quantity{}))
-		})
-
-		It("should return empty quantity when no requests", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.VolumeResourceRequirements{},
-				},
-			}
-
-			storageRequest := getStorageRequest(pvc)
-			Expect(storageRequest).To(Equal(resource.Quantity{}))
-		})
-
-		Describe("calculateCurrentUsage function coverage", func() {
-			It("should handle storage requests correctly", func() {
-				// Create a PVC first
-				pvc := &corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pvc",
-						Namespace: testNamespace.Name,
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceStorage: resource.MustParse("10Gi"),
-							},
-						},
-					},
-				}
-				_, err := k8sClient.CoreV1().PersistentVolumeClaims(testNamespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, testNamespace.Name, usage.ResourceRequestsStorage)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(Equal(int64(10 * 1024 * 1024 * 1024))) // 10Gi in bytes
-			})
-
-			It("should handle storage with specific storage class", func() {
-				storageClass := premiumSSDStorageClass
-				// Create a PVC with specific storage class
-				pvc := &corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pvc-premium",
-						Namespace: testNamespace.Name,
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClass,
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceStorage: resource.MustParse("20Gi"),
-							},
-						},
-					},
-				}
-				_, err := k8sClient.CoreV1().PersistentVolumeClaims(testNamespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, testNamespace.Name,
-					corev1.ResourceName("premium-ssd.storageclass.storage.k8s.io/requests.storage"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(Equal(int64(20 * 1024 * 1024 * 1024))) // 20Gi in bytes
-			})
-
-			It("should return error for unsupported resource types", func() {
-				_, err := webhook.calculateCurrentUsage(ctx, testNamespace.Name, corev1.ResourceName("unsupported.resource"))
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unsupported resource type"))
-			})
-
-			It("should handle non-existent namespace", func() {
-				usage, err := webhook.calculateCurrentUsage(ctx, "non-existent-namespace", usage.ResourceRequestsStorage)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.IsZero()).To(BeTrue())
-			})
-
-			It("should handle PVC count calculation", func() {
-				// Create multiple PVCs to test count
-				for i := 0; i < 3; i++ {
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("count-pvc-%d", i),
-							Namespace: testNamespace.Name,
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("5Gi"),
-								},
-							},
-						},
-					}
-					_, err := k8sClient.CoreV1().PersistentVolumeClaims(testNamespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}
-
-				// Test PVC count
-				usage, err := webhook.calculateCurrentUsage(ctx, testNamespace.Name, corev1.ResourceName("persistentvolumeclaims"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(BeNumerically("==", 3)) // Should count the PVCs
-			})
-
-			It("should handle storage class specific PVC count", func() {
-				storageClass := "fast-ssd"
-				// Create PVCs with specific storage class
-				for i := 0; i < 2; i++ {
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("fast-pvc-%d", i),
-							Namespace: testNamespace.Name,
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &storageClass,
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("15Gi"),
-								},
-							},
-						},
-					}
-					_, err := k8sClient.CoreV1().PersistentVolumeClaims(testNamespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}
-
-				// Test storage class specific PVC count
-				usage, err := webhook.calculateCurrentUsage(
-					ctx,
-					testNamespace.Name,
-					corev1.ResourceName(fastSSDStorageClassResourceName),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(BeNumerically("==", 2)) // Should count the PVCs with specific storage class
-			})
-
-			Describe("validateOperation edge cases", func() {
-				var namespace *corev1.Namespace
-				var crq *quotav1alpha1.ClusterResourceQuota
-				var ctx context.Context
-
-				BeforeEach(func() {
-					namespace = &corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "storage-test-ns",
-							Labels: map[string]string{
-								"test-label": "storage-validation",
-							},
-						},
-					}
-					Expect(fakeRuntimeClient.Create(ctx, namespace)).To(Succeed())
-					// Also create in k8sClient for storage calculator
-					_, err := k8sClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					crq = &quotav1alpha1.ClusterResourceQuota{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "storage-test-crq",
-						},
-						Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"test-label": "storage-validation",
-								},
-							},
-							Hard: quotav1alpha1.ResourceList{
-								"requests.storage": resource.MustParse("100Gi"),
-								"premium-ssd.storageclass.storage.k8s.io/requests.storage": resource.MustParse("50Gi"),
-							},
-						},
-					}
-					Expect(fakeRuntimeClient.Create(ctx, crq)).To(Succeed())
-				})
-
-				It("should validate storage class specific quotas", func() {
-					storageClass := premiumSSDStorageClass
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "premium-test-pvc",
-							Namespace: "storage-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &storageClass,
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("60Gi"), // Exceeds storage class quota
-								},
-							},
-						},
-					}
-
-					err := webhook.validateOperation(ctx, pvc)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("premium-ssd.storageclass.storage.k8s.io/requests.storage"))
-				})
-
-				It("should validate general storage quota when storage class quota passes", func() {
-					storageClass := premiumSSDStorageClass
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "general-test-pvc",
-							Namespace: "storage-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &storageClass,
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("30Gi"), // Within storage class quota but test general
-								},
-							},
-						},
-					}
-
-					// Add existing PVCs to push general storage over limit
-					for i := 0; i < 5; i++ {
-						existingPVC := &corev1.PersistentVolumeClaim{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      fmt.Sprintf("existing-pvc-%d", i),
-								Namespace: "storage-test-ns",
-							},
-							Spec: corev1.PersistentVolumeClaimSpec{
-								Resources: corev1.VolumeResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceStorage: resource.MustParse("20Gi"),
-									},
-								},
-							},
-						}
-						_, err := k8sClient.CoreV1().PersistentVolumeClaims("storage-test-ns").Create(
-							ctx, existingPVC, metav1.CreateOptions{})
-						Expect(err).NotTo(HaveOccurred())
-					}
-
-					err := webhook.validateOperation(ctx, pvc)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("requests.storage"))
-				})
-
-				It("should handle PVC without storage class", func() {
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "no-storage-class-pvc",
-							Namespace: "storage-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("5Gi"),
-								},
-							},
-						},
-					}
-
-					err := webhook.validateOperation(ctx, pvc)
-					Expect(err).NotTo(HaveOccurred()) // Should pass with general storage quota
-				})
-
-				It("should handle missing storage requests", func() {
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "no-storage-requests-pvc",
-							Namespace: "storage-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								// No requests specified
-							},
-						},
-					}
-
-					err := webhook.validateOperation(ctx, pvc)
-					Expect(err).NotTo(HaveOccurred()) // Should pass when no storage requested
-				})
-			})
-
-			Describe("validateUpdate edge cases", func() {
-				var namespace *corev1.Namespace
-				var crq *quotav1alpha1.ClusterResourceQuota
-				var ctx context.Context
-
-				BeforeEach(func() {
-					namespace = &corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "update-test-ns",
-							Labels: map[string]string{
-								"test-label": "update-validation",
-							},
-						},
-					}
-					Expect(fakeRuntimeClient.Create(ctx, namespace)).To(Succeed())
-					// Also create in k8sClient for storage calculator
-					_, err := k8sClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					crq = &quotav1alpha1.ClusterResourceQuota{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "update-test-crq",
-						},
-						Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"test-label": "update-validation",
-								},
-							},
-							Hard: quotav1alpha1.ResourceList{
-								"requests.storage": resource.MustParse("50Gi"),
-							},
-						},
-					}
-					Expect(fakeRuntimeClient.Create(ctx, crq)).To(Succeed())
-				})
-
-				It("should allow updates that don't increase storage", func() {
-					// Create original PVC
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "update-pvc",
-							Namespace: "update-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("10Gi"),
-								},
-							},
-						},
-					}
-					Expect(fakeRuntimeClient.Create(ctx, pvc)).To(Succeed())
-
-					// Simulate update with same storage
-					updatedPVC := pvc.DeepCopy()
-					// Just change labels, not storage
-					updatedPVC.Labels = map[string]string{"updated": "true"}
-
-					err := webhook.validateOperation(ctx, updatedPVC)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should validate updates that increase storage", func() {
-					// Create original PVC
-					pvc := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "expand-pvc",
-							Namespace: "update-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("10Gi"),
-								},
-							},
-						},
-					}
-					_, err := k8sClient.CoreV1().PersistentVolumeClaims("update-test-ns").Create(ctx, pvc, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					// Fill up quota with another PVC
-					otherPVC := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "other-pvc",
-							Namespace: "update-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("35Gi"), // Total would be 45Gi
-								},
-							},
-						},
-					}
-					_, err = k8sClient.CoreV1().PersistentVolumeClaims("update-test-ns").Create(ctx, otherPVC, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					// Try to expand beyond quota
-					updatedPVC := pvc.DeepCopy()
-					// Would make total 55Gi > 50Gi
-					updatedPVC.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("20Gi")
-
-					err = webhook.validateOperation(ctx, updatedPVC)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("requests.storage"))
-				})
-
-				It("should handle update with nil PVC", func() {
-					newPVC := &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "nil-test-pvc",
-							Namespace: "update-test-ns",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("5Gi"),
-								},
-							},
-						},
-					}
-
-					err := webhook.validateOperation(ctx, newPVC)
-					Expect(err).NotTo(HaveOccurred()) // Should validate as normal
-				})
-			})
-		})
-	})
-})
-
-// Helper functions
-func createPVCAdmissionReview(pvc *corev1.PersistentVolumeClaim,
-	operation admissionv1.Operation) admissionv1.AdmissionReview {
-	// Encode the PVC to raw bytes
-	scheme := runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-	codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
-
-	pvcBytes, err := runtime.Encode(codec, pvc)
-	Expect(err).NotTo(HaveOccurred())
-
-	return admissionv1.AdmissionReview{
-		Request: &admissionv1.AdmissionRequest{
-			UID: "test-uid",
-			Kind: metav1.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "PersistentVolumeClaim",
-			},
-			Resource: metav1.GroupVersionResource{
-				Group:    "",
-				Version:  "v1",
-				Resource: "persistentvolumeclaims",
-			},
-			Operation: operation,
-			Namespace: pvc.Namespace,
-			Object: runtime.RawExtension{
-				Raw: pvcBytes,
-			},
+const pvcWebhookTestNamespace = "pvc-ns"
+
+func newPVCReview(uid string, pvc *corev1.PersistentVolumeClaim) *admissionv1.AdmissionReview {
+	raw, _ := json.Marshal(pvc)
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
 		},
-		Response: &admissionv1.AdmissionResponse{
-			UID: "test-uid",
+		Request: &admissionv1.AdmissionRequest{
+			UID:       types.UID(uid),
+			Namespace: pvcWebhookTestNamespace,
+			Operation: admissionv1.Create,
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+			Resource: metav1.GroupVersionResource{
+				Group: "", Version: "v1", Resource: "persistentvolumeclaims",
+			},
+			Object: runtime.RawExtension{Raw: raw},
 		},
 	}
 }
 
-func sendPVCWebhookRequest(ginEngine *gin.Engine,
-	admissionReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	body, err := json.Marshal(admissionReview)
-	Expect(err).NotTo(HaveOccurred())
-
-	req, _ := http.NewRequest("POST", "/pvc", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	ginEngine.ServeHTTP(w, req)
-
-	Expect(w.Code).To(Equal(http.StatusOK))
-
-	var response admissionv1.AdmissionReview
-	err = json.Unmarshal(w.Body.Bytes(), &response)
-	Expect(err).NotTo(HaveOccurred())
-
-	return response.Response
+func makePVC(name, storage, storageClass string) *corev1.PersistentVolumeClaim {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pvcWebhookTestNamespace},
+	}
+	if storage != "" {
+		pvc.Spec.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse(storage),
+		}
+	}
+	if storageClass != "" {
+		pvc.Spec.StorageClassName = &storageClass
+	}
+	return pvc
 }
+
+var _ = Describe("PersistentVolumeClaimWebhook", func() {
+	const (
+		nsName  = pvcWebhookTestNamespace
+		crqName = "pvc-crq"
+	)
+	var (
+		engine *gin.Engine
+		labels = map[string]string{"team": "alpha"}
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		engine = gin.New()
+	})
+
+	Describe("NewPersistentVolumeClaimWebhook", func() {
+		It("constructs with all dependencies", func() {
+			client := newTestCRQClient()
+			h := NewPersistentVolumeClaimWebhook(client, zap.NewNop())
+			Expect(h).NotTo(BeNil())
+			Expect(h.crqClient).To(Equal(client))
+		})
+
+		It("uses a no-op logger when nil is passed", func() {
+			h := NewPersistentVolumeClaimWebhook(nil, nil)
+			Expect(h).NotTo(BeNil())
+			Expect(h.logger).NotTo(BeNil())
+		})
+	})
+
+	Describe("getStorageRequest", func() {
+		It("returns the storage value when present", func() {
+			pvc := makePVC("p", "10Gi", "")
+			q := getStorageRequest(pvc)
+			Expect(q.Cmp(resource.MustParse("10Gi"))).To(Equal(0))
+		})
+
+		It("returns the zero quantity when no requests are set", func() {
+			pvc := &corev1.PersistentVolumeClaim{}
+			q := getStorageRequest(pvc)
+			Expect(q.IsZero()).To(BeTrue())
+		})
+	})
+
+	Describe("Handle (status-read path)", func() {
+		It("admits a PVC when storage is under the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("100Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("10Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("1"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPVCReview("1", makePVC("p1", "5Gi", "")))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies a PVC when storage would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("10Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("10Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("0"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPVCReview("2", makePVC("p1", "1Gi", "")))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("requests.storage limit exceeded"))
+		})
+
+		It("denies a PVC when the PVC count would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourcePersistentVolumeClaims: quantity("2"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourcePersistentVolumeClaims: quantity("2"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPVCReview("3", makePVC("p1", "", "")))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("persistentvolumeclaims limit exceeded"))
+		})
+
+		It("validates storage-class-prefixed keys when StorageClassName is set", func() {
+			ns := makeNamespace(nsName, labels)
+			scStorageKey := corev1.ResourceName("fast.storageclass.storage.k8s.io/requests.storage")
+			scPVCCountKey := corev1.ResourceName("fast.storageclass.storage.k8s.io/persistentvolumeclaims")
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("100Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("10"),
+					scStorageKey:                         quantity("5Gi"),
+					scPVCCountKey:                        quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("0"),
+					usage.ResourcePersistentVolumeClaims: quantity("0"),
+					scStorageKey:                         quantity("5Gi"),
+					scPVCCountKey:                        quantity("0"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPVCReview("4", makePVC("p1", "1Gi", "fast")))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("storage class 'fast' storage validation failed"))
+		})
+
+		It("admits when no CRQ matches the namespace", func() {
+			ns := makeNamespace(nsName, labels)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPVCReview("5", makePVC("p1", "10Gi", "")))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("admits when the CRQ client is nil", func() {
+			h := NewPersistentVolumeClaimWebhook(nil, zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPVCReview("6", makePVC("p1", "10Gi", "")))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("rejects DELETE as unsupported", func() {
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newPVCReview("7", makePVC("p1", "10Gi", ""))
+			review.Request.Operation = admissionv1.Delete
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Operation DELETE is not supported"))
+		})
+	})
+})

--- a/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook_test.go
+++ b/pkg/webhook/v1alpha1/persistentvolumeclaim_webhook_test.go
@@ -210,5 +210,78 @@ var _ = Describe("PersistentVolumeClaimWebhook", func() {
 			Expect(resp.Response.Allowed).To(BeFalse())
 			Expect(resp.Response.Result.Message).To(ContainSubstring("Operation DELETE is not supported"))
 		})
+
+		It("admits an Update when storage grows within quota (resize)", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("10Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("5Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("1"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newPVCReview("8", makePVC("p1", "6Gi", ""))
+			oldRaw, _ := json.Marshal(makePVC("p1", "5Gi", ""))
+			review.Request.OldObject = runtime.RawExtension{Raw: oldRaw}
+			review.Request.Operation = admissionv1.Update
+
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies an Update when storage growth would exceed quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("8Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("5Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("1"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newPVCReview("9", makePVC("p1", "10Gi", ""))
+			oldRaw, _ := json.Marshal(makePVC("p1", "5Gi", ""))
+			review.Request.OldObject = runtime.RawExtension{Raw: oldRaw}
+			review.Request.Operation = admissionv1.Update
+
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("requests.storage limit exceeded"))
+		})
+
+		It("admits an Update that does not change storage (no-op for quota)", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("5Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("1"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsStorage:        quantity("5Gi"),
+					usage.ResourcePersistentVolumeClaims: quantity("1"),
+				},
+			)
+			h := NewPersistentVolumeClaimWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newPVCReview("10", makePVC("p1", "5Gi", ""))
+			oldRaw, _ := json.Marshal(makePVC("p1", "5Gi", ""))
+			review.Request.OldObject = runtime.RawExtension{Raw: oldRaw}
+			review.Request.Operation = admissionv1.Update
+
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
 	})
 })

--- a/pkg/webhook/v1alpha1/pod_webhook.go
+++ b/pkg/webhook/v1alpha1/pod_webhook.go
@@ -8,7 +8,6 @@ import (
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/pod"
@@ -120,7 +119,7 @@ func (h *PodWebhook) validateOperation(
 	}
 
 	if op == admissionv1.Create {
-		if err := validateCRQStatusUsage(crq, usage.ResourcePods, resource.MustParse("1"), h.logger, correlationID); err != nil {
+		if err := validateCRQStatusUsage(crq, usage.ResourcePods, oneQuantity, h.logger, correlationID); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota pod count validation failed: %w", err)
 		}
 	}

--- a/pkg/webhook/v1alpha1/pod_webhook.go
+++ b/pkg/webhook/v1alpha1/pod_webhook.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/pod"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
@@ -19,15 +18,12 @@ import (
 
 // PodWebhook handles webhook requests for Pod resources
 type PodWebhook struct {
-	client        kubernetes.Interface
-	podCalculator pod.PodResourceCalculator
-	crqClient     *quota.CRQClient
-	logger        *zap.Logger
+	crqClient *quota.CRQClient
+	logger    *zap.Logger
 }
 
 // NewPodWebhook creates a new PodWebhook
 func NewPodWebhook(
-	k8sClient kubernetes.Interface,
 	crqClient *quota.CRQClient,
 	logger *zap.Logger,
 ) *PodWebhook {
@@ -36,10 +32,8 @@ func NewPodWebhook(
 	}
 	logger = logger.Named("pod-webhook")
 	return &PodWebhook{
-		client:        k8sClient,
-		podCalculator: *pod.NewPodResourceCalculator(k8sClient, logger),
-		crqClient:     crqClient,
-		logger:        logger,
+		crqClient: crqClient,
+		logger:    logger,
 	}
 }
 
@@ -56,9 +50,6 @@ func (h *PodWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *PodWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
 	switch req.Operation {
 	case admissionv1.Create, admissionv1.Update:
@@ -98,6 +89,13 @@ func (h *PodWebhook) validateOperation(
 		return nil, nil
 	}
 
+	crq := resolveCRQForNamespace(ctx, h.crqClient, h.logger, podObj.Namespace)
+	if crq == nil {
+		return nil, nil
+	}
+
+	correlationID := quota.GetCorrelationID(ctx)
+
 	computeResources := []struct {
 		resource corev1.ResourceName
 		label    string
@@ -111,26 +109,18 @@ func (h *PodWebhook) validateOperation(
 	for _, c := range computeResources {
 		delta := pod.CalculatePodUsage(podObj, c.resource)
 		if oldPod != nil {
-			oldUsage := pod.CalculatePodUsage(oldPod, c.resource)
-			delta.Sub(oldUsage)
+			delta.Sub(pod.CalculatePodUsage(oldPod, c.resource))
 		}
 		if delta.Sign() <= 0 {
 			continue
 		}
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			podObj.Namespace, c.resource, delta, h.calculateCurrentUsage,
-		); err != nil {
+		if err := validateCRQStatusUsage(crq, c.resource, delta, h.logger, correlationID); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota %s validation failed: %w", c.label, err)
 		}
 	}
 
 	if op == admissionv1.Create {
-		podCount := resource.NewQuantity(1, resource.DecimalSI)
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			podObj.Namespace, usage.ResourcePods, *podCount, h.calculateCurrentUsage,
-		); err != nil {
+		if err := validateCRQStatusUsage(crq, usage.ResourcePods, resource.MustParse("1"), h.logger, correlationID); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota pod count validation failed: %w", err)
 		}
 	}
@@ -141,21 +131,4 @@ func (h *PodWebhook) validateOperation(
 		zap.String("operation", string(op)),
 	)
 	return nil, nil
-}
-
-// calculateCurrentUsage calculates the current usage of a resource in a namespace
-func (h *PodWebhook) calculateCurrentUsage(ctx context.Context, namespace string,
-	resourceName corev1.ResourceName) (resource.Quantity, error) {
-	switch resourceName {
-	case usage.ResourceRequestsCPU, usage.ResourceRequestsMemory, usage.ResourceLimitsCPU, usage.ResourceLimitsMemory:
-		return h.podCalculator.CalculateUsage(ctx, namespace, resourceName)
-	case usage.ResourcePods:
-		count, err := h.podCalculator.CalculatePodCount(ctx, namespace)
-		if err != nil {
-			return resource.Quantity{}, err
-		}
-		return *resource.NewQuantity(count, resource.DecimalSI), nil
-	default:
-		return resource.Quantity{}, fmt.Errorf("unsupported resource type: %s", resourceName)
-	}
 }

--- a/pkg/webhook/v1alpha1/pod_webhook_test.go
+++ b/pkg/webhook/v1alpha1/pod_webhook_test.go
@@ -1,12 +1,7 @@
 package v1alpha1
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,1578 +12,406 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/apimachinery/pkg/types"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
-	pkglogger "github.com/powerhome/pac-quota-controller/pkg/logger"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
 )
 
+const podWebhookTestNamespace = "pod-ns"
+
+func newPodReview(uid string, pod *corev1.Pod) *admissionv1.AdmissionReview {
+	raw, _ := json.Marshal(pod)
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       types.UID(uid),
+			Namespace: podWebhookTestNamespace,
+			Operation: admissionv1.Create,
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func makePod(name, cpuReq, memReq, cpuLim, memLim string) *corev1.Pod {
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+	if cpuReq != "" {
+		requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
+	}
+	if memReq != "" {
+		requests[corev1.ResourceMemory] = resource.MustParse(memReq)
+	}
+	if cpuLim != "" {
+		limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
+	}
+	if memLim != "" {
+		limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: podWebhookTestNamespace},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "c",
+					Image: "busybox",
+					Resources: corev1.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+}
+
 var _ = Describe("PodWebhook", func() {
+	const (
+		nsName  = podWebhookTestNamespace
+		crqName = "pod-crq"
+	)
 	var (
-		ctx               context.Context
-		webhook           *PodWebhook
-		fakeClient        kubernetes.Interface
-		fakeRuntimeClient client.Client
-		crqClient         *quota.CRQClient
-		logger            *zap.Logger
-		ginEngine         *gin.Engine
-		testNamespace     *corev1.Namespace
+		engine *gin.Engine
+		labels = map[string]string{"team": "alpha"}
 	)
 
 	BeforeEach(func() {
-		testNamespace = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-namespace",
-			},
-		}
-		fakeClient = fake.NewSimpleClientset(testNamespace)
-		scheme := runtime.NewScheme()
-		_ = quotav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		fakeRuntimeClient = ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
-		logger = pkglogger.L()
-		crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-		webhook = NewPodWebhook(fakeClient, crqClient, logger)
 		gin.SetMode(gin.TestMode)
-		ginEngine = gin.New()
-		ginEngine.POST("/webhook", webhook.Handle)
+		engine = gin.New()
 	})
 
-	Describe("Handle", func() {
-		It("should handle valid pod creation request", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-			Expect(response.Response.UID).To(Equal(admissionReview.Request.UID))
+	Describe("NewPodWebhook", func() {
+		It("constructs with all dependencies", func() {
+			client := newTestCRQClient()
+			h := NewPodWebhook(client, zap.NewNop())
+			Expect(h).NotTo(BeNil())
+			Expect(h.crqClient).To(Equal(client))
 		})
 
-		It("should handle valid pod update request (resize subresource)", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Update)
-			admissionReview.Request.SubResource = "resize"
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-			Expect(response.Response.UID).To(Equal(admissionReview.Request.UID))
-		})
-
-		It("should reject DELETE with unsupportedOperationError", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{Name: "test-container"},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Delete)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Code).To(Equal(int32(http.StatusBadRequest)))
-			Expect(response.Response.Result.Message).To(ContainSubstring("Operation DELETE is not supported for Pod"))
-		})
-
-		It("should reject request with nil admission review", func() {
-			req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer([]byte("{}")))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("should reject request with nil admission review request", func() {
-			admissionReview := &admissionv1.AdmissionReview{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "AdmissionReview",
-					APIVersion: "admission.k8s.io/v1",
-				},
-				Request: nil,
-			}
-
-			admissionReviewJSON, err := json.Marshal(admissionReview)
-			Expect(err).NotTo(HaveOccurred())
-			req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer(admissionReviewJSON))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("should reject request with wrong resource kind", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			admissionReview.Request.Kind = metav1.GroupVersionKind{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
-			}
-
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("Expected Pod resource"))
-		})
-
-		It("should reject request with invalid JSON", func() {
-			req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer([]byte("invalid json")))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("should handle pod with no containers", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-
-		It("should handle pod with init containers", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name: "init-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("50m"),
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "main-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-
-		It("should handle pod with large resource requests", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1000m"),
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2000m"),
-									corev1.ResourceMemory: resource.MustParse("2Gi"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-
-		It("should handle pod with custom resources", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									"nvidia.com/gpu": resource.MustParse("1"),
-									"hugepages-2Mi":  resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-
-		It("should handle pod with no resource requests", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-
-		It("should reject request with wrong resource kind", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			admissionReview.Request.Kind = metav1.GroupVersionKind{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
-			}
-
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("Expected Pod resource"))
+		It("uses a no-op logger when nil is passed", func() {
+			h := NewPodWebhook(nil, nil)
+			Expect(h).NotTo(BeNil())
+			Expect(h.logger).NotTo(BeNil())
 		})
 	})
 
-	Describe("validateCreate", func() {
-		It("should validate pod creation", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
+	Describe("Handle (status-read path)", func() {
+		It("admits a pod when all resources stay under the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU:    quantity("4"),
+					usage.ResourceRequestsMemory: quantity("4Gi"),
+					usage.ResourceLimitsCPU:      quantity("8"),
+					usage.ResourceLimitsMemory:   quantity("8Gi"),
+					usage.ResourcePods:           quantity("10"),
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100m"),
-								},
-							},
-						},
-					},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU:    quantity("1"),
+					usage.ResourceRequestsMemory: quantity("1Gi"),
+					usage.ResourceLimitsCPU:      quantity("2"),
+					usage.ResourceLimitsMemory:   quantity("2Gi"),
+					usage.ResourcePods:           quantity("2"),
 				},
-			}
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			warnings, err := webhook.validateOperation(ctx, pod, nil, admissionv1.Create)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(warnings).To(BeNil())
-		})
-	})
-
-	Describe("validateUpdate", func() {
-		It("should validate pod update", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			warnings, err := webhook.validateOperation(ctx, pod, nil, admissionv1.Update)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(warnings).To(BeNil())
-		})
-	})
-
-	Describe("validateOperation", func() {
-		It("should validate pod operation for creation", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-						},
-					},
-				},
-			}
-
-			warnings, err := webhook.validateOperation(ctx, pod, nil, "creation")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(warnings).To(BeNil())
+			pod := makePod("p1", "1", "1Gi", "2", "2Gi")
+			resp := sendWebhookRequest(engine, newPodReview("1", pod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
-		It("should validate pod operation for update", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
+		It("denies when CPU requests would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("2"),
+					usage.ResourcePods:        quantity("10"),
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-						},
-					},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("2"),
+					usage.ResourcePods:        quantity("0"),
 				},
-			}
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			warnings, err := webhook.validateOperation(ctx, pod, nil, "update")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(warnings).To(BeNil())
+			pod := makePod("p1", "1", "", "", "")
+			resp := sendWebhookRequest(engine, newPodReview("2", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("CPU requests"))
+			Expect(resp.Response.Result.Message).To(ContainSubstring("requests.cpu limit exceeded"))
 		})
 
-		It("should handle nil pod", func() {
-			warnings, err := webhook.validateOperation(ctx, nil, nil, "creation")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(warnings).To(BeNil())
-		})
-	})
-
-	Describe("Edge Cases", func() {
-		It("should handle pod with very long name", func() {
-			longName := "very-long-pod-name-that-exceeds-normal-length-limits-for-testing-purposes"
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      longName,
-					Namespace: "test-namespace",
+		It("denies when memory requests would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsMemory: quantity("1Gi"),
+					usage.ResourcePods:           quantity("10"),
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-						},
-					},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsMemory: quantity("1Gi"),
+					usage.ResourcePods:           quantity("0"),
 				},
-			}
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
+			pod := makePod("p1", "", "512Mi", "", "")
+			resp := sendWebhookRequest(engine, newPodReview("3", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("memory requests"))
 		})
 
-		It("should handle pod with special characters in name", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod-123_456-789",
-					Namespace: "test-namespace",
+		It("denies when CPU limits would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsCPU: quantity("2"),
+					usage.ResourcePods:      quantity("10"),
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-						},
-					},
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsCPU: quantity("2"),
+					usage.ResourcePods:      quantity("0"),
 				},
-			}
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
+			pod := makePod("p1", "", "", "1", "")
+			resp := sendWebhookRequest(engine, newPodReview("4", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("CPU limits"))
 		})
 
-		It("should handle pod with multiple containers", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
+		It("denies when memory limits would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsMemory: quantity("1Gi"),
+					usage.ResourcePods:         quantity("10"),
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "container-1",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100m"),
-								},
-							},
-						},
-						{
-							Name: "container-2",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
-								},
-							},
-						},
-					},
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsMemory: quantity("1Gi"),
+					usage.ResourcePods:         quantity("0"),
 				},
-			}
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(pod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-	})
-
-	Describe("Cross-Namespace Quota Validation", func() {
-		var (
-			crq         *quotav1alpha1.ClusterResourceQuota
-			namespace1  *corev1.Namespace
-			namespace2  *corev1.Namespace
-			namespace3  *corev1.Namespace // For non-matching namespace tests
-			existingPod *corev1.Pod
-		)
-
-		BeforeEach(func() {
-			// Create test namespaces with matching labels
-			namespace1 = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-ns-1",
-					Labels: map[string]string{
-						"environment": "test",
-						"team":        "platform",
-					},
-				},
-			}
-			namespace2 = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-ns-2",
-					Labels: map[string]string{
-						"environment": "test",
-						"team":        "platform",
-					},
-				},
-			}
-
-			// Create a namespace that doesn't match the CRQ selector
-			namespace3 = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-ns-3",
-					Labels: map[string]string{
-						"environment": "production",
-						"team":        "backend",
-					},
-				},
-			}
-
-			// Create a ClusterResourceQuota that selects both test namespaces
-			crq = &quotav1alpha1.ClusterResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-crq",
-				},
-				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"environment": "test",
-						},
-					},
-					Hard: quotav1alpha1.ResourceList{
-						corev1.ResourceRequestsCPU:    resource.MustParse("300m"),
-						corev1.ResourceRequestsMemory: resource.MustParse("300Mi"),
-					},
-				},
-			}
-
-			// Create an existing pod in namespace1 that consumes resources
-			existingPod = &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "existing-pod",
-					Namespace: "test-ns-1",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "existing-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
-									corev1.ResourceMemory: resource.MustParse("200Mi"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			// Update the fake clients with the new resources
-			fakeClient = fake.NewSimpleClientset(testNamespace, namespace1, namespace2, namespace3, existingPod)
-			scheme := runtime.NewScheme()
-			_ = quotav1alpha1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
-			fakeRuntimeClient = ctrlclientfake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(crq, namespace1, namespace2, namespace3).
-				Build()
-			crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-
-			// Recreate webhook with updated clients
-			webhook = NewPodWebhook(fakeClient, crqClient, logger)
-
-			// Re-setup gin engine
-			ginEngine = gin.New()
-			ginEngine.POST("/webhook", webhook.Handle)
+			pod := makePod("p1", "", "", "", "256Mi")
+			resp := sendWebhookRequest(engine, newPodReview("5", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("memory limits"))
 		})
 
-		AfterEach(func() {
-			// Clean up cross-namespace test resources
-			crq = nil
-			namespace1 = nil
-			namespace2 = nil
-			namespace3 = nil
-			existingPod = nil
+		It("denies when the pod count would exceed the quota even with no resource requests", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{usage.ResourcePods: quantity("2")},
+				quotav1alpha1.ResourceList{usage.ResourcePods: quantity("2")},
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			pod := makePod("p1", "", "", "", "")
+			resp := sendWebhookRequest(engine, newPodReview("6", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("pod count"))
+			Expect(resp.Response.Result.Message).To(ContainSubstring("pods limit exceeded"))
 		})
 
-		It("should reject pod that would exceed cross-namespace quota limits", func() {
-			// Try to create a new pod in namespace2 that would exceed the total quota
-			newPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-pod",
-					Namespace: "test-ns-2",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "new-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("150m"), // 200m + 150m = 350m > 300m limit
-								},
-							},
-						},
-					},
-				},
-			}
+		It("admits when no CRQ matches the namespace", func() {
+			ns := makeNamespace(nsName, labels)
+			h := NewPodWebhook(newTestCRQClient(ns), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(newPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("CPU requests validation failed"))
-			Expect(response.Response.Result.Message).To(ContainSubstring("test-crq"))
-			Expect(response.Response.Result.Message).To(ContainSubstring("limit exceeded"))
+			pod := makePod("p1", "1", "1Gi", "", "")
+			resp := sendWebhookRequest(engine, newPodReview("7", pod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
-		It("should allow pod that fits within cross-namespace quota limits", func() {
-			// Try to create a new pod in namespace2 that fits within the total quota
-			newPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-pod",
-					Namespace: "test-ns-2",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "new-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),  // 200m + 50m = 250m < 300m limit
-									corev1.ResourceMemory: resource.MustParse("50Mi"), // 200Mi + 50Mi = 250Mi < 300Mi limit
-								},
-							},
-						},
-					},
-				},
-			}
+		It("admits when the CRQ client is nil", func() {
+			h := NewPodWebhook(nil, zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(newPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
+			pod := makePod("p1", "1", "1Gi", "", "")
+			resp := sendWebhookRequest(engine, newPodReview("8", pod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
-		It("should allow pod in namespace not matching CRQ selector", func() {
-			// Try to create a pod in namespace3 (doesn't match CRQ selector) with high resource requests
-			newPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "unmatched-pod",
-					Namespace: "test-ns-3",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("1000m"), // High request, but no CRQ applies
-								},
-							},
-						},
-					},
-				},
-			}
+		It("denies non-Pod GVK", func() {
+			h := NewPodWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(newPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
+			review := newPodReview("9", makePod("p", "", "", "", ""))
+			review.Request.Kind = metav1.GroupVersionKind{Kind: "Service"}
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Expected Pod"))
 		})
 
-		It("should handle complex label selectors", func() {
-			// Create a test namespace that matches the complex selector
-			complexNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "complex-ns",
-					Labels: map[string]string{
-						"team":        "platform",
-						"environment": "staging", // Not production, not test
-					},
-				},
-			}
+		It("rejects DELETE as unsupported", func() {
+			h := NewPodWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			// Create a CRQ with complex label selector (MatchExpressions)
-			complexCRQ := &quotav1alpha1.ClusterResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "complex-crq",
-				},
-				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "team",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"platform", "backend"},
-							},
-							{
-								Key:      "environment",
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{"production"},
-							},
-						},
-					},
-					Hard: quotav1alpha1.ResourceList{
-						corev1.ResourceRequestsCPU: resource.MustParse("500m"),
-					},
-				},
-			}
-
-			// Update clients with new resources
-			fakeClient = fake.NewSimpleClientset(
-				testNamespace, namespace1, namespace2, namespace3, existingPod, complexNamespace)
-			err := fakeRuntimeClient.Create(ctx, complexCRQ)
-			Expect(err).NotTo(HaveOccurred())
-			err = fakeRuntimeClient.Create(ctx, complexNamespace)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Recreate webhook with updated client
-			webhook = NewPodWebhook(fakeClient, crqClient, logger)
-			ginEngine = gin.New()
-			ginEngine.POST("/webhook", webhook.Handle)
-
-			// Try to create a pod in the complex namespace (should match complex selector)
-			newPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "complex-pod",
-					Namespace: "complex-ns",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(newPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
+			review := newPodReview("10", makePod("p", "", "", "", ""))
+			review.Request.Operation = admissionv1.Delete
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Operation DELETE is not supported"))
 		})
 
-		It("should handle multiple containers across namespaces", func() {
-			// Create a pod with multiple containers that would exceed limits
-			multiContainerPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "multi-container-pod",
-					Namespace: "test-ns-2",
+		It("admits (fail-open) when CRQ status is missing the requested resource", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("2"),
+					usage.ResourcePods:        quantity("10"),
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "container-1",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("80m"),
-								},
-							},
-						},
-						{
-							Name: "container-2",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("80m"),
-								},
-							},
-						},
-					},
-				},
-			}
+				// Status only populates pods; cpu is missing.
+				quotav1alpha1.ResourceList{usage.ResourcePods: quantity("0")},
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
 
-			admissionReview := createPodAdmissionReview(multiContainerPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			// 200m (existing) + 80m + 80m = 360m > 300m limit
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("test-crq"))
-			Expect(response.Response.Result.Message).To(ContainSubstring("limit exceeded"))
-		})
-
-		It("should handle init containers in cross-namespace scenario", func() {
-			// Create a pod with init containers that would exceed limits
-			initContainerPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "init-container-pod",
-					Namespace: "test-ns-2",
-				},
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name: "init-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("150m"),
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "main-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(initContainerPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			// Should use max(init: 150m, main: 100m) = 150m
-			// 200m (existing) + 150m = 350m > 300m limit
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("test-crq"))
-		})
-
-		It("should validate memory resources across namespaces", func() {
-			// Create a pod that would exceed memory limits
-			memoryPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "memory-pod",
-					Namespace: "test-ns-2",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "memory-container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("150Mi"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(memoryPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			// 200Mi (existing) + 150Mi = 350Mi > 300Mi limit
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("memory requests validation failed"))
-			Expect(response.Response.Result.Message).To(ContainSubstring("test-crq"))
-		})
-
-		It("should handle CRQ with no matching namespaces", func() {
-			// Create a namespace with unique labels for this test
-			isolatedNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "isolated-ns",
-					Labels: map[string]string{
-						"isolated": "true",
-					},
-				},
-			}
-
-			// Create a CRQ that doesn't match any namespaces
-			noMatchCRQ := &quotav1alpha1.ClusterResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "no-match-crq",
-				},
-				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"nonexistent": "label",
-						},
-					},
-					Hard: quotav1alpha1.ResourceList{
-						corev1.ResourceRequestsCPU: resource.MustParse("100m"),
-					},
-				},
-			}
-
-			// Update clients with new resources
-			fakeClient = fake.NewSimpleClientset(
-				testNamespace, namespace1, namespace2, namespace3, existingPod, isolatedNamespace)
-			err := fakeRuntimeClient.Create(ctx, noMatchCRQ)
-			Expect(err).NotTo(HaveOccurred())
-			err = fakeRuntimeClient.Create(ctx, isolatedNamespace)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Recreate webhook with updated client
-			webhook = NewPodWebhook(fakeClient, crqClient, logger)
-			ginEngine = gin.New()
-			ginEngine.POST("/webhook", webhook.Handle)
-
-			// Create a pod in the isolated namespace - should be allowed since CRQ doesn't apply
-			newPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-match-pod",
-					Namespace: "isolated-ns",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "container",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("500m"),
-								},
-							},
-						},
-					},
-				},
-			}
-
-			admissionReview := createPodAdmissionReview(newPod, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-
-		Describe("calculateCurrentUsage function coverage", func() {
-			It("should handle CPU requests correctly", func() {
-				// Create a pod with CPU requests
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cpu-test-pod",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("500m"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("test-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, "test-namespace", corev1.ResourceName("requests.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.MilliValue()).To(Equal(int64(500))) // 500m CPU
-			})
-
-			It("should handle memory requests correctly", func() {
-				// Create a pod with memory requests
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "memory-test-pod",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("256Mi"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("test-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, "test-namespace", corev1.ResourceName("requests.memory"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(Equal(int64(256 * 1024 * 1024))) // 256Mi in bytes
-			})
-
-			It("should handle CPU limits correctly", func() {
-				// Create a pod with CPU limits
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cpu-limit-test-pod",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Limits: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("1"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("test-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, "test-namespace", corev1.ResourceName("limits.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.MilliValue()).To(Equal(int64(1000))) // 1 CPU = 1000m
-			})
-
-			It("should handle memory limits correctly", func() {
-				// Create a pod with memory limits
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "memory-limit-test-pod",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("512Mi"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("test-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, "test-namespace", corev1.ResourceName("limits.memory"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(Equal(int64(512 * 1024 * 1024))) // 512Mi in bytes
-			})
-
-			It("should handle pods in terminal states (Succeeded)", func() {
-				testTerminalPodState(ctx, corev1.PodSucceeded, "succeeded-pod", "terminal-test-namespace",
-					&fakeClient, crqClient, logger)
-			})
-
-			It("should handle pods in terminal states (Failed)", func() {
-				testTerminalPodState(ctx, corev1.PodFailed, "failed-pod", "failed-test-namespace",
-					&fakeClient, crqClient, logger)
-			})
-
-			It("should handle pods with both init and regular containers", func() {
-				// Create a fresh namespace for this test to ensure clean state
-				testNs := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "init-container-test-namespace",
-					},
-				}
-				fakeClient = fake.NewSimpleClientset(testNs)
-				webhook = NewPodWebhook(fakeClient, crqClient, logger)
-
-				// Create a pod with both init and regular containers
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "init-and-regular-pod",
-						Namespace: "init-container-test-namespace",
-					},
-					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{
-							{
-								Name:  "init-container",
-								Image: "busybox:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("50m"),
-									},
-								},
-							},
-						},
-						Containers: []corev1.Container{
-							{
-								Name:  "main-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("100m"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("init-container-test-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(
-					ctx,
-					"init-container-test-namespace",
-					corev1.ResourceName("requests.cpu"),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				// Should use Max(init: 50m, main: 100m) = 100m
-				Expect(usage.MilliValue()).To(Equal(int64(100)))
-			})
-
-			It("should return error for unsupported resource types", func() {
-				_, err := webhook.calculateCurrentUsage(ctx, "test-namespace", corev1.ResourceName("unsupported.resource"))
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unsupported resource type"))
-			})
-
-			It("should handle pod count calculation", func() {
-				// Create a fresh namespace for this test to ensure clean state
-				testNs := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "pod-count-namespace",
-					},
-				}
-				fakeClient = fake.NewSimpleClientset(testNs)
-				webhook = NewPodWebhook(fakeClient, crqClient, logger)
-
-				// Create multiple pods to test count
-				for i := 0; i < 3; i++ {
-					pod := &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("count-pod-%d", i),
-							Namespace: "pod-count-namespace",
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "test-container",
-									Image: "nginx:latest",
-								},
-							},
-						},
-					}
-					_, err := fakeClient.CoreV1().Pods("pod-count-namespace").Create(ctx, pod, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}
-
-				// Test pod count
-				usage, err := webhook.calculateCurrentUsage(ctx, "pod-count-namespace", corev1.ResourceName("pods"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.Value()).To(Equal(int64(3))) // Should count 3 pods
-			})
-
-			It("should handle non-existent namespace", func() {
-				usage, err := webhook.calculateCurrentUsage(ctx, "non-existent-namespace", corev1.ResourceName("requests.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.IsZero()).To(BeTrue())
-			})
-
-			It("should handle namespace with no pods", func() {
-				// Create empty namespace
-				emptyNs := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "empty-namespace",
-					},
-				}
-				Expect(fakeRuntimeClient.Create(ctx, emptyNs)).To(Succeed())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, "empty-namespace", corev1.ResourceName("requests.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usage.IsZero()).To(BeTrue())
-			})
-
-			It("should handle zero resource requests/limits", func() {
-				// Create a fresh namespace for this test to ensure clean state
-				testNs := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "zero-resource-namespace",
-					},
-				}
-				fakeClient = fake.NewSimpleClientset(testNs)
-				webhook = NewPodWebhook(fakeClient, crqClient, logger)
-
-				// Create a pod with zero resource requests (should contribute 0 to usage)
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "zero-resource-pod",
-						Namespace: "zero-resource-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("0"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("zero-resource-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				usage, err := webhook.calculateCurrentUsage(ctx, "zero-resource-namespace", corev1.ResourceName("requests.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				// Should be 0 since the pod requests 0 CPU
-				Expect(usage.MilliValue()).To(Equal(int64(0)))
-			})
-
-			It("should handle mixed resource types in same pod", func() {
-				// Create a fresh namespace for this test to ensure clean state
-				testNs := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "mixed-resource-namespace",
-					},
-				}
-				fakeClient = fake.NewSimpleClientset(testNs)
-				webhook = NewPodWebhook(fakeClient, crqClient, logger)
-
-				// Create a pod with mixed resource types to test calculator behavior
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "mixed-resource-pod",
-						Namespace: "mixed-resource-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("100m"),
-										corev1.ResourceMemory: resource.MustParse("128Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("200m"),
-										corev1.ResourceMemory: resource.MustParse("256Mi"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("mixed-resource-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// Test CPU requests
-				cpuUsage, err := webhook.calculateCurrentUsage(ctx, "mixed-resource-namespace", corev1.ResourceName("requests.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cpuUsage.MilliValue()).To(Equal(int64(100))) // Just this pod: 100m
-
-				// Test memory limits
-				memoryUsage, err := webhook.calculateCurrentUsage(
-					ctx,
-					"mixed-resource-namespace",
-					corev1.ResourceName("limits.memory"),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				expectedMemory := int64(256 * 1024 * 1024) // 256Mi
-				Expect(memoryUsage.Value()).To(Equal(expectedMemory))
-			})
-
-			It("should handle multiple containers with different resource patterns", func() {
-				// Create a fresh namespace for this test to ensure clean state
-				testNs := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "multi-pattern-namespace",
-					},
-				}
-				fakeClient = fake.NewSimpleClientset(testNs)
-				webhook = NewPodWebhook(fakeClient, crqClient, logger)
-
-				// Create a pod with multiple containers having different resource configurations
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "multi-pattern-pod",
-						Namespace: "multi-pattern-namespace",
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "cpu-only-container",
-								Image: "nginx:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("50m"),
-									},
-								},
-							},
-							{
-								Name:  "memory-only-container",
-								Image: "redis:latest",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("64Mi"),
-									},
-								},
-							},
-							{
-								Name:  "limits-only-container",
-								Image: "postgres:latest",
-								Resources: corev1.ResourceRequirements{
-									Limits: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("200m"),
-									},
-								},
-							},
-						},
-					},
-				}
-				_, err := fakeClient.CoreV1().Pods("multi-pattern-namespace").Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// Test CPU requests (should only count cpu-only-container)
-				cpuUsage, err := webhook.calculateCurrentUsage(ctx, "multi-pattern-namespace", corev1.ResourceName("requests.cpu"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cpuUsage.MilliValue()).To(Equal(int64(50))) // Just this pod: 50m
-
-				// Test memory requests (should only count memory-only-container)
-				memoryUsage, err := webhook.calculateCurrentUsage(
-					ctx,
-					"multi-pattern-namespace",
-					corev1.ResourceName("requests.memory"),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				expectedMemory := int64(64 * 1024 * 1024) // 64Mi
-				Expect(memoryUsage.Value()).To(Equal(expectedMemory))
-
-				// Test CPU limits (should only count limits-only-container)
-				cpuLimitsUsage, err := webhook.calculateCurrentUsage(
-					ctx,
-					"multi-pattern-namespace",
-					corev1.ResourceName("limits.cpu"),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cpuLimitsUsage.MilliValue()).To(Equal(int64(200))) // 200m
-			})
+			pod := makePod("p1", "5", "", "", "")
+			resp := sendWebhookRequest(engine, newPodReview("11", pod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 	})
 
 	Describe("Pod Resize (UPDATE) Quota Validation", func() {
-		var (
-			resizeCRQ       *quotav1alpha1.ClusterResourceQuota
-			resizeNS        *corev1.Namespace
-			existingPodOld  *corev1.Pod
-			runResizeReview func(newRequests corev1.ResourceList, oldRequests corev1.ResourceList) admissionv1.AdmissionResponse
-		)
-
-		BeforeEach(func() {
-			resizeNS = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "resize-ns",
-					Labels: map[string]string{"resize-test": "true"},
-				},
-			}
-			resizeCRQ = &quotav1alpha1.ClusterResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "resize-crq"},
-				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"resize-test": "true"},
-					},
-					Hard: quotav1alpha1.ResourceList{
-						corev1.ResourceRequestsCPU: resource.MustParse("200m"),
-						corev1.ResourcePods:        resource.MustParse("1"),
-					},
-				},
-			}
-			// existingPodOld represents the pre-resize pod already present in the
-			// namespace; tests rewrite its CPU requests via the oldRequests arg.
-			existingPodOld = &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "resize-pod",
-					Namespace: "resize-ns",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{Name: "main", Resources: corev1.ResourceRequirements{}},
-					},
-				},
-			}
-
-			runResizeReview = func(newRequests, oldRequests corev1.ResourceList) admissionv1.AdmissionResponse {
-				oldPod := existingPodOld.DeepCopy()
-				oldPod.Spec.Containers[0].Resources.Requests = oldRequests
-				newPod := existingPodOld.DeepCopy()
-				newPod.Spec.Containers[0].Resources.Requests = newRequests
-
-				// The pod currently in the namespace must reflect the pre-resize
-				// state so calculateCurrentUsage returns the old usage.
-				fakeClient = fake.NewSimpleClientset(testNamespace, resizeNS, oldPod)
-				scheme := runtime.NewScheme()
-				_ = quotav1alpha1.AddToScheme(scheme)
-				_ = corev1.AddToScheme(scheme)
-				fakeRuntimeClient = ctrlclientfake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(resizeCRQ, resizeNS).
-					Build()
-				crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-				webhook = NewPodWebhook(fakeClient, crqClient, logger)
-				ginEngine = gin.New()
-				ginEngine.POST("/webhook", webhook.Handle)
-
-				review := createPodResizeAdmissionReview(newPod, oldPod)
-				return *sendWebhookRequest(ginEngine, review).Response
-			}
-		})
+		// resizeReview builds a review matching what the apiserver sends for the
+		// pods/resize subresource: Operation=UPDATE, SubResource="resize", and
+		// OldObject populated with the pre-resize pod.
+		resizeReview := func(uid string, newPod, oldPod *corev1.Pod) *admissionv1.AdmissionReview {
+			r := newPodReview(uid, newPod)
+			r.Request.Operation = admissionv1.Update
+			r.Request.SubResource = "resize"
+			oldRaw, _ := json.Marshal(oldPod)
+			r.Request.OldObject = runtime.RawExtension{Raw: oldRaw}
+			return r
+		}
 
 		It("allows a resize up when the delta fits in remaining quota", func() {
-			// quota=200m, oldUsage=50m, newUsage=100m, delta=50m -> 50+50=100 <= 200.
-			resp := runResizeReview(
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("1"),
+					usage.ResourcePods:        quantity("10"),
+				},
+				// Existing pod uses 50m; remaining = 950m.
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("50m"),
+					usage.ResourcePods:        quantity("1"),
+				},
 			)
-			Expect(resp.Allowed).To(BeTrue())
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			oldPod := makePod("p1", "50m", "", "", "")
+			newPod := makePod("p1", "60m", "", "", "")
+			resp := sendWebhookRequest(engine, resizeReview("r1", newPod, oldPod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
 		It("rejects a resize up when the delta exceeds remaining quota", func() {
-			// quota=200m, oldUsage=100m, newUsage=250m, delta=150m -> 100+150=250 > 200.
-			resp := runResizeReview(
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("100m"),
+					usage.ResourcePods:        quantity("10"),
+				},
+				// Quota fully consumed by the existing pod.
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("100m"),
+					usage.ResourcePods:        quantity("1"),
+				},
 			)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Message).To(ContainSubstring("CPU requests validation failed"))
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			oldPod := makePod("p1", "100m", "", "", "")
+			newPod := makePod("p1", "200m", "", "", "")
+			resp := sendWebhookRequest(engine, resizeReview("r2", newPod, oldPod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("requests.cpu limit exceeded"))
 		})
 
 		It("allows a resize up that would fail without delta accounting", func() {
-			// quota=200m, oldUsage=180m, newUsage=200m, delta=20m -> 180+20=200 OK.
-			// Naive (non-delta) check would compute 180+200=380m and reject.
-			resp := runResizeReview(
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("180m")},
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("1"),
+					usage.ResourcePods:        quantity("10"),
+				},
+				// 900m already used; without delta accounting, charging the full
+				// new 200m would exceed (900m + 200m = 1100m > 1).
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("900m"),
+					usage.ResourcePods:        quantity("1"),
+				},
 			)
-			Expect(resp.Allowed).To(BeTrue())
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			oldPod := makePod("p1", "100m", "", "", "")
+			newPod := makePod("p1", "200m", "", "", "")
+			// Delta is 100m; 900m + 100m = 1 (fits exactly).
+			resp := sendWebhookRequest(engine, resizeReview("r3", newPod, oldPod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
 		It("allows a resize down even when quota is fully consumed", func() {
-			// quota=200m, oldUsage=200m, newUsage=50m, delta<=0 -> early-continue.
-			resp := runResizeReview(
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("100m"),
+					usage.ResourcePods:        quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("100m"),
+					usage.ResourcePods:        quantity("1"),
+				},
 			)
-			Expect(resp.Allowed).To(BeTrue())
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			oldPod := makePod("p1", "100m", "", "", "")
+			newPod := makePod("p1", "50m", "", "", "")
+			resp := sendWebhookRequest(engine, resizeReview("r4", newPod, oldPod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
 		It("does not charge +1 pod count on UPDATE (resize fits with pod count at limit)", func() {
-			// pods quota=1 and one pod already exists. A resize must not be
-			// rejected by the +1 pod-count charge that we only apply on CREATE.
-			resp := runResizeReview(
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("60m")},
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("1"),
+					usage.ResourcePods:        quantity("1"),
+				},
+				// Pod count already at the hard limit; an UPDATE must not be
+				// rejected by a +1 pod-count charge (only CREATE charges count).
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsCPU: quantity("50m"),
+					usage.ResourcePods:        quantity("1"),
+				},
 			)
-			Expect(resp.Allowed).To(BeTrue())
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			oldPod := makePod("p1", "50m", "", "", "")
+			newPod := makePod("p1", "60m", "", "", "")
+			resp := sendWebhookRequest(engine, resizeReview("r5", newPod, oldPod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 	})
 })
-
-// Helper functions for testing
-
-func createPodAdmissionReview(pod *corev1.Pod, operation admissionv1.Operation) *admissionv1.AdmissionReview {
-	raw, _ := json.Marshal(pod)
-	return &admissionv1.AdmissionReview{
-		Request: &admissionv1.AdmissionRequest{
-			UID: "test-uid",
-			Kind: metav1.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Pod",
-			},
-			Resource: metav1.GroupVersionResource{
-				Group:    "",
-				Version:  "v1",
-				Resource: "pods",
-			},
-			Operation: operation,
-			Namespace: pod.Namespace,
-			Object: runtime.RawExtension{
-				Raw: raw,
-			},
-		},
-	}
-}
-
-// createPodResizeAdmissionReview builds an admission review that matches what
-// the apiserver sends for the pods/resize subresource: Operation=UPDATE,
-// SubResource="resize", and OldObject populated with the pre-resize pod.
-func createPodResizeAdmissionReview(newPod, oldPod *corev1.Pod) *admissionv1.AdmissionReview {
-	review := createPodAdmissionReview(newPod, admissionv1.Update)
-	review.Request.SubResource = "resize"
-	oldRaw, _ := json.Marshal(oldPod)
-	review.Request.OldObject = runtime.RawExtension{Raw: oldRaw}
-	return review
-}
-
-// testTerminalPodState is a helper function to test pods in terminal states (Succeeded/Failed)
-func testTerminalPodState(ctx context.Context, phase corev1.PodPhase, podName, namespaceName string,
-	fakeClient *kubernetes.Interface, crqClient *quota.CRQClient, logger *zap.Logger) {
-	// Create a fresh namespace for this test to ensure clean state
-	testNs := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespaceName,
-		},
-	}
-	*fakeClient = fake.NewSimpleClientset(testNs)
-	webhook := NewPodWebhook(*fakeClient, crqClient, logger)
-
-	// Create a pod in the specified terminal state (should not count towards usage)
-	cpuRequest := "100m"
-	if phase == corev1.PodFailed {
-		cpuRequest = "200m"
-	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespaceName,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "test-container",
-					Image: "nginx:latest",
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse(cpuRequest),
-						},
-					},
-				},
-			},
-		},
-		Status: corev1.PodStatus{
-			Phase: phase,
-		},
-	}
-	_, err := (*fakeClient).CoreV1().Pods(namespaceName).Create(ctx, pod, metav1.CreateOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	usage, err := webhook.calculateCurrentUsage(ctx, namespaceName, "requests.cpu")
-	Expect(err).NotTo(HaveOccurred())
-	// Should not include the terminal pod's resources
-	Expect(usage.Value()).To(Equal(int64(0)))
-}

--- a/pkg/webhook/v1alpha1/service_webhook.go
+++ b/pkg/webhook/v1alpha1/service_webhook.go
@@ -8,7 +8,6 @@ import (
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
@@ -73,7 +72,6 @@ func (h *ServiceWebhook) validateOperation(
 	}
 
 	correlationID := quota.GetCorrelationID(ctx)
-	one := *resource.NewQuantity(1, resource.DecimalSI)
 
 	resourceNames := []corev1.ResourceName{usage.ResourceServices}
 	switch svc.Spec.Type {
@@ -84,7 +82,7 @@ func (h *ServiceWebhook) validateOperation(
 	}
 
 	for _, rn := range resourceNames {
-		if err := validateCRQStatusUsage(crq, rn, one, h.logger, correlationID); err != nil {
+		if err := validateCRQStatusUsage(crq, rn, oneQuantity, h.logger, correlationID); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota service count validation failed for %s: %w", rn, err)
 		}
 	}

--- a/pkg/webhook/v1alpha1/service_webhook.go
+++ b/pkg/webhook/v1alpha1/service_webhook.go
@@ -10,25 +10,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/services"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
 )
 
 // ServiceWebhook handles webhook requests for Service resources.
 // It enforces object count quotas for services and subtypes.
 type ServiceWebhook struct {
-	client            kubernetes.Interface
-	serviceCalculator services.ServiceResourceCalculator
-	crqClient         *quota.CRQClient
-	logger            *zap.Logger
+	crqClient *quota.CRQClient
+	logger    *zap.Logger
 }
 
 // NewServiceWebhook creates a new ServiceWebhook
 func NewServiceWebhook(
-	k8sClient kubernetes.Interface,
 	crqClient *quota.CRQClient,
 	logger *zap.Logger,
 ) *ServiceWebhook {
@@ -37,10 +32,8 @@ func NewServiceWebhook(
 	}
 	logger = logger.Named("service-webhook")
 	return &ServiceWebhook{
-		client:            k8sClient,
-		serviceCalculator: *services.NewServiceResourceCalculator(k8sClient, logger),
-		crqClient:         crqClient,
-		logger:            logger,
+		crqClient: crqClient,
+		logger:    logger,
 	}
 }
 
@@ -53,9 +46,6 @@ func (h *ServiceWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *ServiceWebhook) validate(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error) {
 	switch req.Operation {
 	case admissionv1.Create, admissionv1.Update:
@@ -77,23 +67,24 @@ func (h *ServiceWebhook) validateOperation(
 	svc *corev1.Service,
 	op admissionv1.Operation,
 ) ([]string, error) {
-	var subtype corev1.ResourceName
+	crq := resolveCRQForNamespace(ctx, h.crqClient, h.logger, svc.Namespace)
+	if crq == nil {
+		return nil, nil
+	}
+
+	correlationID := quota.GetCorrelationID(ctx)
+	one := *resource.NewQuantity(1, resource.DecimalSI)
+
+	resourceNames := []corev1.ResourceName{usage.ResourceServices}
 	switch svc.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
-		subtype = usage.ResourceServicesLoadBalancers
+		resourceNames = append(resourceNames, usage.ResourceServicesLoadBalancers)
 	case corev1.ServiceTypeNodePort:
-		subtype = usage.ResourceServicesNodePorts
-	}
-	resourceNames := []corev1.ResourceName{usage.ResourceServices}
-	if subtype != "" {
-		resourceNames = append(resourceNames, subtype)
+		resourceNames = append(resourceNames, usage.ResourceServicesNodePorts)
 	}
 
 	for _, rn := range resourceNames {
-		if err := validateAgainstCRQ(
-			ctx, h.client, h.crqClient, h.logger,
-			svc.Namespace, rn, *resource.NewQuantity(1, resource.DecimalSI), h.calculateCurrentUsage,
-		); err != nil {
+		if err := validateCRQStatusUsage(crq, rn, one, h.logger, correlationID); err != nil {
 			return nil, fmt.Errorf("ClusterResourceQuota service count validation failed for %s: %w", rn, err)
 		}
 	}
@@ -103,14 +94,4 @@ func (h *ServiceWebhook) validateOperation(
 		zap.String("namespace", svc.Namespace),
 		zap.String("operation", string(op)))
 	return nil, nil
-}
-
-func (h *ServiceWebhook) calculateCurrentUsage(ctx context.Context, namespace string,
-	resourceName corev1.ResourceName) (resource.Quantity, error) {
-	switch resourceName {
-	case usage.ResourceServices, usage.ResourceServicesLoadBalancers, usage.ResourceServicesNodePorts:
-		return h.serviceCalculator.CalculateUsage(ctx, namespace, resourceName)
-	default:
-		return resource.Quantity{}, fmt.Errorf("unsupported resource type: %s", resourceName)
-	}
 }

--- a/pkg/webhook/v1alpha1/service_webhook.go
+++ b/pkg/webhook/v1alpha1/service_webhook.go
@@ -57,13 +57,24 @@ func (h *ServiceWebhook) validate(ctx context.Context, req *admissionv1.Admissio
 		return nil, err
 	}
 
-	return h.validateOperation(ctx, &svc, req.Operation)
+	var oldSvc *corev1.Service
+	if req.Operation == admissionv1.Update && len(req.OldObject.Raw) > 0 {
+		var s corev1.Service
+		if err := decodeAdmissionObject(req.OldObject.Raw, &s, "Service"); err != nil {
+			return nil, err
+		}
+		oldSvc = &s
+	}
+
+	return h.validateOperation(ctx, &svc, oldSvc, req.Operation)
 }
 
-// validateOperation is shared between create and update validation.
+// validateOperation runs per-resource count checks. On Update, charges +1
+// only for resources the new service belongs to that the old service did not.
 func (h *ServiceWebhook) validateOperation(
 	ctx context.Context,
 	svc *corev1.Service,
+	oldSvc *corev1.Service,
 	op admissionv1.Operation,
 ) ([]string, error) {
 	crq := resolveCRQForNamespace(ctx, h.crqClient, h.logger, svc.Namespace)
@@ -73,17 +84,19 @@ func (h *ServiceWebhook) validateOperation(
 
 	correlationID := quota.GetCorrelationID(ctx)
 
-	resourceNames := []corev1.ResourceName{usage.ResourceServices}
-	switch svc.Spec.Type {
-	case corev1.ServiceTypeLoadBalancer:
-		resourceNames = append(resourceNames, usage.ResourceServicesLoadBalancers)
-	case corev1.ServiceTypeNodePort:
-		resourceNames = append(resourceNames, usage.ResourceServicesNodePorts)
+	already := map[corev1.ResourceName]bool{}
+	if oldSvc != nil {
+		for _, r := range serviceQuotaResources(oldSvc) {
+			already[r] = true
+		}
 	}
 
-	for _, rn := range resourceNames {
-		if err := validateCRQStatusUsage(crq, rn, oneQuantity, h.logger, correlationID); err != nil {
-			return nil, fmt.Errorf("ClusterResourceQuota service count validation failed for %s: %w", rn, err)
+	for _, r := range serviceQuotaResources(svc) {
+		if already[r] {
+			continue
+		}
+		if err := validateCRQStatusUsage(crq, r, oneQuantity, h.logger, correlationID); err != nil {
+			return nil, fmt.Errorf("ClusterResourceQuota service count validation failed for %s: %w", r, err)
 		}
 	}
 
@@ -92,4 +105,15 @@ func (h *ServiceWebhook) validateOperation(
 		zap.String("namespace", svc.Namespace),
 		zap.String("operation", string(op)))
 	return nil, nil
+}
+
+func serviceQuotaResources(svc *corev1.Service) []corev1.ResourceName {
+	out := []corev1.ResourceName{usage.ResourceServices}
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeLoadBalancer:
+		out = append(out, usage.ResourceServicesLoadBalancers)
+	case corev1.ServiceTypeNodePort:
+		out = append(out, usage.ResourceServicesNodePorts)
+	}
+	return out
 }

--- a/pkg/webhook/v1alpha1/service_webhook_test.go
+++ b/pkg/webhook/v1alpha1/service_webhook_test.go
@@ -207,4 +207,117 @@ var _ = Describe("ServiceWebhook", func() {
 			Expect(resp.Response.Result.Message).To(ContainSubstring("Expected Service"))
 		})
 	})
+
+	Describe("Handle UPDATE", func() {
+		updateReview := func(uid string, newSvc, oldSvc *corev1.Service) *admissionv1.AdmissionReview {
+			r := newServiceReview(uid, newSvc)
+			r.Request.Operation = admissionv1.Update
+			oldRaw, _ := json.Marshal(oldSvc)
+			r.Request.OldObject = runtime.RawExtension{Raw: oldRaw}
+			return r
+		}
+
+		It("allows updating a service when services count is at the limit", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{usage.ResourceServices: quantity("2")},
+				quotav1alpha1.ResourceList{usage.ResourceServices: quantity("2")},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			old := makeService(corev1.ServiceTypeClusterIP)
+			new := makeService(corev1.ServiceTypeClusterIP)
+			resp := sendWebhookRequest(engine, updateReview("u1", new, old))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("allows updating a LoadBalancer when LB quota is at the limit and type is unchanged", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("10"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("1"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			old := makeService(corev1.ServiceTypeLoadBalancer)
+			new := makeService(corev1.ServiceTypeLoadBalancer)
+			resp := sendWebhookRequest(engine, updateReview("u2", new, old))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies a ClusterIP -> LoadBalancer transition when LB quota is full", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("10"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("1"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			old := makeService(corev1.ServiceTypeClusterIP)
+			new := makeService(corev1.ServiceTypeLoadBalancer)
+			resp := sendWebhookRequest(engine, updateReview("u3", new, old))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("services.loadbalancers limit exceeded"))
+		})
+
+		It("allows a LoadBalancer -> ClusterIP transition even when LB quota is full", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("10"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("1"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			old := makeService(corev1.ServiceTypeLoadBalancer)
+			new := makeService(corev1.ServiceTypeClusterIP)
+			resp := sendWebhookRequest(engine, updateReview("u4", new, old))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies a NodePort -> LoadBalancer transition when LB quota is full", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("10"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+					usage.ResourceServicesNodePorts:     quantity("5"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("1"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+					usage.ResourceServicesNodePorts:     quantity("0"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			old := makeService(corev1.ServiceTypeNodePort)
+			new := makeService(corev1.ServiceTypeLoadBalancer)
+			resp := sendWebhookRequest(engine, updateReview("u5", new, old))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("services.loadbalancers limit exceeded"))
+		})
+	})
 })

--- a/pkg/webhook/v1alpha1/service_webhook_test.go
+++ b/pkg/webhook/v1alpha1/service_webhook_test.go
@@ -1,11 +1,7 @@
 package v1alpha1
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo/v2"
@@ -13,853 +9,202 @@ import (
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/apimachinery/pkg/types"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/services"
-	pkglogger "github.com/powerhome/pac-quota-controller/pkg/logger"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
 )
 
-var _ = Describe("ServiceWebhook", func() {
-	var (
-		ctx               context.Context
-		webhook           *ServiceWebhook
-		fakeClient        kubernetes.Interface
-		fakeRuntimeClient client.Client
-		crqClient         *quota.CRQClient
-		logger            *zap.Logger
-		ginEngine         *gin.Engine
-		testNamespace     *corev1.Namespace
-	)
+const serviceWebhookTestNamespace = "svc-ns"
 
-	BeforeEach(func() {
-		testNamespace = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-namespace",
-			},
-		}
-		fakeClient = fake.NewSimpleClientset(testNamespace)
-		scheme := runtime.NewScheme()
-		_ = quotav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		logger = pkglogger.L()
-		fakeRuntimeClient = ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
-		crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-		webhook = &ServiceWebhook{
-			client:            fakeClient,
-			serviceCalculator: *services.NewServiceResourceCalculator(fakeClient, logger),
-			crqClient:         crqClient,
-			logger:            logger,
-		}
-		gin.SetMode(gin.TestMode)
-		ginEngine = gin.New()
-		ginEngine.POST("/webhook", webhook.Handle)
-	})
-	Describe("Service type and error handling (integration style)", func() {
-		It("should allow ClusterIP service within quota", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svc-clusterip",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.ServiceSpec{
-					Type:  corev1.ServiceTypeClusterIP,
-					Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}},
-				},
-			}
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-		It("should allow NodePort service within quota", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svc-nodeport",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.ServiceSpec{
-					Type:  corev1.ServiceTypeNodePort,
-					Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}},
-				},
-			}
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-		It("should allow LoadBalancer service within quota", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svc-lb",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.ServiceSpec{
-					Type:  corev1.ServiceTypeLoadBalancer,
-					Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}},
-				},
-			}
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-		It("should allow ExternalName service within quota", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svc-external",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.ServiceSpec{
-					Type:         corev1.ServiceTypeExternalName,
-					ExternalName: "example.com",
-				},
-			}
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-			Expect(response.Response.Allowed).To(BeTrue())
-		})
-		It("should reject if namespace does not exist", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svc-missing-ns",
-					Namespace: "does-not-exist",
-				},
-				Spec: corev1.ServiceSpec{
-					Type:  corev1.ServiceTypeClusterIP,
-					Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}},
-				},
-			}
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("failed to get namespace"))
-		})
-	})
-
-	Describe("Handle", func() {
-		It("should handle valid service creation request", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-service",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "http",
-							Port:       80,
-							TargetPort: intstr.FromInt(8080),
-						},
-					},
-				},
-			}
-
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-			Expect(response.Response.UID).To(Equal(admissionReview.Request.UID))
-		})
-
-		It("should handle valid service update request", func() {
-			svc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-service",
-					Namespace: "test-namespace",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "http",
-							Port:       80,
-							TargetPort: intstr.FromInt(8081),
-						},
-					},
-				},
-			}
-
-			admissionReview := createServiceAdmissionReview(svc, admissionv1.Update)
-			response := sendWebhookRequest(ginEngine, admissionReview)
-
-			Expect(response.Response.Allowed).To(BeTrue())
-			Expect(response.Response.UID).To(Equal(admissionReview.Request.UID))
-		})
-
-		It("should reject request with nil admission review", func() {
-			req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer([]byte("{}")))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("should reject request with nil admission review request", func() {
-			admissionReview := &admissionv1.AdmissionReview{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "AdmissionReview",
-					APIVersion: "admission.k8s.io/v1",
-				},
-				Request: nil,
-			}
-			body, _ := json.Marshal(admissionReview)
-			req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("should reject request with wrong resource kind", func() {
-			// Use a ConfigMap as a wrong kind
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cm",
-					Namespace: "test-namespace",
-				},
-			}
-			raw, _ := json.Marshal(cm)
-			admissionReview := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					UID: "test-uid",
-					Kind: metav1.GroupVersionKind{
-						Group:   "",
-						Version: "v1",
-						Kind:    "ConfigMap",
-					},
-					Resource: metav1.GroupVersionResource{
-						Group:    "",
-						Version:  "v1",
-						Resource: "configmaps",
-					},
-					Operation: admissionv1.Create,
-					Namespace: "test-namespace",
-					Object: runtime.RawExtension{
-						Raw: raw,
-					},
-				},
-			}
-			response := sendWebhookRequest(ginEngine, admissionReview)
-			Expect(response.Response.Allowed).To(BeFalse())
-			Expect(response.Response.Result.Message).To(ContainSubstring("Expected Service resource"))
-		})
-
-		It("should reject request with invalid JSON", func() {
-			req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer([]byte("invalid json")))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			ginEngine.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		Describe("validateCreate", func() {
-			It("should validate service creation", func() {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-service",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-				warnings, err := webhook.validateOperation(ctx, svc, admissionv1.Create)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(warnings).To(BeNil())
-			})
-		})
-
-		Describe("validateUpdate", func() {
-			It("should validate service update", func() {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-service",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-				warnings, err := webhook.validateOperation(ctx, svc, admissionv1.Update)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(warnings).To(BeNil())
-			})
-		})
-
-		Describe("Edge Cases", func() {
-			It("should handle svc with very long name", func() {
-				longName := "very-long-svc-name-that-exceeds-normal-length-limits-for-testing-purposes"
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      longName,
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-
-				admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-
-			It("should handle svc with special characters in name", func() {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-svc-123_456-789",
-						Namespace: "test-namespace",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-
-				admissionReview := createServiceAdmissionReview(svc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-		})
-		Describe("Cross-Namespace Quota Validation", func() {
-			var (
-				crq          *quotav1alpha1.ClusterResourceQuota
-				namespace1   *corev1.Namespace
-				namespace2   *corev1.Namespace
-				namespace3   *corev1.Namespace // For non-matching namespace tests
-				existingSvc1 *corev1.Service
-				existingSvc2 *corev1.Service
-				existingSvc3 *corev1.Service
-			)
-
-			BeforeEach(func() {
-				// Create test namespaces with matching labels
-				namespace1 = &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-ns-1",
-						Labels: map[string]string{
-							"environment": "test",
-							"team":        "platform",
-						},
-					},
-				}
-				namespace2 = &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-ns-2",
-						Labels: map[string]string{
-							"environment": "test",
-							"team":        "platform",
-						},
-					},
-				}
-
-				// Create a namespace that doesn't match the CRQ selector
-				namespace3 = &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-ns-3",
-						Labels: map[string]string{
-							"environment": "production",
-							"team":        "backend",
-						},
-					},
-				}
-
-				// Create a ClusterResourceQuota that selects both test namespaces
-				crq = &quotav1alpha1.ClusterResourceQuota{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-crq",
-					},
-					Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"environment": "test",
-							},
-						},
-						Hard: quotav1alpha1.ResourceList{
-							corev1.ResourceServices:              resource.MustParse("3"),
-							corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
-							corev1.ResourceServicesNodePorts:     resource.MustParse("1"),
-						},
-					},
-				}
-
-				// Create existing services in namespace1 with unique names
-				existingSvc1 = &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-svc-lb",
-						Namespace: "test-ns-1",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeLoadBalancer,
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-				existingSvc2 = &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-svc-nodeport",
-						Namespace: "test-ns-1",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeNodePort,
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-				existingSvc3 = &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-svc-clusterip",
-						Namespace: "test-ns-1",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-
-				// Update the fake clients with the new resources
-				fakeClient = fake.NewSimpleClientset(
-					testNamespace,
-					namespace1,
-					namespace2,
-					namespace3,
-					existingSvc1,
-					existingSvc2,
-					existingSvc3,
-				)
-				scheme := runtime.NewScheme()
-				_ = quotav1alpha1.AddToScheme(scheme)
-				_ = corev1.AddToScheme(scheme)
-				fakeRuntimeClient = ctrlclientfake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(crq, namespace1, namespace2, namespace3, existingSvc1, existingSvc2, existingSvc3).
-					Build()
-				crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-
-				// Recreate webhook with updated clients
-				webhook = NewServiceWebhook(fakeClient, crqClient, logger)
-
-				// Re-setup gin engine
-				ginEngine = gin.New()
-				ginEngine.POST("/webhook", webhook.Handle)
-			})
-
-			AfterEach(func() {
-				// Clean up cross-namespace test resources
-				crq = nil
-				namespace1 = nil
-				namespace2 = nil
-				namespace3 = nil
-				existingSvc1 = nil
-				existingSvc2 = nil
-				existingSvc3 = nil
-			})
-
-			It("should reject svc that would exceed cross-namespace quota limits", func() {
-				// Try to create a new service in namespace2 that would exceed the total quota
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-svc",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeLoadBalancer,
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-
-				Expect(response.Response.Allowed).To(BeFalse())
-				Expect(response.Response.Result.Message).
-					To(ContainSubstring("ClusterResourceQuota service count validation failed for"))
-				Expect(response.Response.Result.Message).
-					To(ContainSubstring("test-crq"))
-				Expect(response.Response.Result.Message).
-					To(ContainSubstring("limit exceeded"))
-			})
-
-			It("should allow svc that fits within cross-namespace quota limits", func() {
-				// Increase the quota to allow one more LoadBalancer service (from 1 to 2)
-				// Also increase the quota total number of services to 4 (from 3)
-				crq.Spec.Hard[corev1.ResourceServices] = resource.MustParse("4")
-				crq.Spec.Hard[corev1.ResourceServicesLoadBalancers] = resource.MustParse("2")
-
-				// Rebuild the fake runtime client with updated CRQ
-				scheme := runtime.NewScheme()
-				_ = quotav1alpha1.AddToScheme(scheme)
-				_ = corev1.AddToScheme(scheme)
-				fakeRuntimeClient = ctrlclientfake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(crq, namespace1, namespace2, namespace3, existingSvc1, existingSvc2, existingSvc3).
-					Build()
-				crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-				webhook = NewServiceWebhook(fakeClient, crqClient, logger)
-				ginEngine = gin.New()
-				ginEngine.POST("/webhook", webhook.Handle)
-
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-svc",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeLoadBalancer,
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-					},
-				}
-
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-
-		})
-
-		// Service admission tests for all service resource types and quota scenarios
-		Describe("Service admission", func() {
-			var (
-				fakeClient        *fake.Clientset
-				fakeRuntimeClient client.Client
-				ginEngine         *gin.Engine
-				crq               *quotav1alpha1.ClusterResourceQuota
-			)
-
-			BeforeEach(func() {
-				// Namespaces
-				ns1 := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "test-ns-1",
-						Labels: map[string]string{"environment": "test"},
-					},
-				}
-				ns2 := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "test-ns-2",
-						Labels: map[string]string{"environment": "test"},
-					},
-				}
-				ns3 := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "test-ns-3",
-						Labels: map[string]string{"environment": "production"},
-					},
-				}
-				// CRQ for all service types
-				crq = &quotav1alpha1.ClusterResourceQuota{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-crq",
-					},
-					Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"environment": "test",
-							},
-						},
-						Hard: quotav1alpha1.ResourceList{
-							corev1.ResourceServices:              resource.MustParse("5"),
-							corev1.ResourceServicesNodePorts:     resource.MustParse("2"),
-							corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
-						},
-					},
-				}
-				fakeClient = fake.NewSimpleClientset(ns1, ns2, ns3)
-				scheme := runtime.NewScheme()
-				_ = quotav1alpha1.AddToScheme(scheme)
-				_ = corev1.AddToScheme(scheme)
-				fakeRuntimeClient = ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(crq, ns1, ns2, ns3).Build()
-				crqClient = quota.NewCRQClient(fakeRuntimeClient, logger)
-				ginEngine = gin.New()
-				webhook = &ServiceWebhook{
-					client:            fakeClient,
-					serviceCalculator: *services.NewServiceResourceCalculator(fakeClient, logger),
-					crqClient:         crqClient,
-					logger:            logger,
-				}
-				ginEngine.POST("/webhook", webhook.Handle)
-			})
-
-			AfterEach(func() {
-				fakeClient = nil
-				fakeRuntimeClient = nil
-				crqClient = nil
-				logger = nil
-				ginEngine = nil
-			})
-
-			It("should allow creation of a ClusterIP service within quota", func() {
-				// No existing services, quota is 5
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-clusterip",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}},
-					},
-				}
-				_, err := fakeClient.CoreV1().Services("test-ns-2").Create(ctx, &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-svc-1",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 81, TargetPort: intstr.FromInt(8081)}},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-
-			It("should reject creation of a NodePort service if NodePort quota exceeded", func() {
-				// Add two NodePort services to reach the quota (quota is 2)
-				_, err := fakeClient.CoreV1().Services("test-ns-1").Create(ctx, &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-nodeport-1",
-						Namespace: "test-ns-1",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeNodePort,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 82, TargetPort: intstr.FromInt(8082)}},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				_, err = fakeClient.CoreV1().Services("test-ns-2").Create(ctx, &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-nodeport-2",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeNodePort,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 83, TargetPort: intstr.FromInt(8083)}},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-nodeport",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeNodePort,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 84, TargetPort: intstr.FromInt(8084)}},
-					},
-				}
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-				Expect(response.Response.Allowed).To(BeFalse())
-				Expect(response.Response.Result.Message).To(ContainSubstring("service count validation failed"))
-			})
-
-			It("should allow creation of an ExternalName service within quota", func() {
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-externalname",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:         corev1.ServiceTypeExternalName,
-						ExternalName: "example.com",
-					},
-				}
-				// Add a ClusterIP service to test-ns-2 to ensure quota logic is exercised
-				_, err := fakeClient.CoreV1().Services("test-ns-2").Create(ctx, &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-svc-ext",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 87, TargetPort: intstr.FromInt(8087)}},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-
-			It("should reject creation of a LoadBalancer service if quota exceeded", func() {
-				// Add a LoadBalancer service to reach the quota (quota is 1)
-				_, err := fakeClient.CoreV1().Services("test-ns-2").Create(ctx, &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-lb",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeLoadBalancer,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 88, TargetPort: intstr.FromInt(8088)}},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-loadbalancer",
-						Namespace: "test-ns-2",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeLoadBalancer,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 89, TargetPort: intstr.FromInt(8089)}},
-					},
-				}
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-				Expect(response.Response.Allowed).To(BeFalse())
-				Expect(response.Response.Result.Message).To(ContainSubstring("service count validation failed"))
-			})
-
-			It("should allow creation of a service in a namespace not matching CRQ selector", func() {
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "unmatched-svc",
-						Namespace: "test-ns-3",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 85, TargetPort: intstr.FromInt(8085)}},
-					},
-				}
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(ginEngine, admissionReview)
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-
-			It("should allow creation when no quota set", func() {
-				// Remove quota for services
-				crq.Spec.Hard = nil
-				// Use a fresh Gin engine to avoid handler registration panic
-				scheme := runtime.NewScheme()
-				_ = quotav1alpha1.AddToScheme(scheme)
-				_ = corev1.AddToScheme(scheme)
-				ns1 := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "test-ns-1",
-						Labels: map[string]string{"environment": "test"},
-					},
-				}
-				fakeRuntimeClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(crq, ns1).Build()
-				crqClient := quota.NewCRQClient(fakeRuntimeClient, logger)
-				webhook := &ServiceWebhook{
-					client:            fakeClient,
-					serviceCalculator: *services.NewServiceResourceCalculator(fakeClient, logger),
-					crqClient:         crqClient,
-					logger:            logger,
-				}
-				freshGin := gin.New()
-				freshGin.POST("/webhook", webhook.Handle)
-				newSvc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "no-quota-svc",
-						Namespace: "test-ns-1",
-					},
-					Spec: corev1.ServiceSpec{
-						Type:  corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{{Name: "http", Port: 86, TargetPort: intstr.FromInt(8086)}},
-					},
-				}
-				admissionReview := createServiceAdmissionReview(newSvc, admissionv1.Create)
-				response := sendWebhookRequest(freshGin, admissionReview)
-				Expect(response.Response.Allowed).To(BeTrue())
-			})
-
-			// Add more tests for error paths, CRQ lookup errors, and edge cases as needed
-		})
-	})
-})
-
-// Helper functions for testing
-func createServiceAdmissionReview(
-	service *corev1.Service,
-	operation admissionv1.Operation,
-) *admissionv1.AdmissionReview {
-	raw, _ := json.Marshal(service)
+func newServiceReview(uid string, svc *corev1.Service) *admissionv1.AdmissionReview {
+	raw, _ := json.Marshal(svc)
 	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
 		Request: &admissionv1.AdmissionRequest{
-			UID: "test-uid",
-			Kind: metav1.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Service",
-			},
-			Resource: metav1.GroupVersionResource{
-				Group:    "",
-				Version:  "v1",
-				Resource: "services",
-			},
-			Operation: operation,
-			Namespace: service.Namespace,
-			Object: runtime.RawExtension{
-				Raw: raw,
-			},
+			UID:       types.UID(uid),
+			Namespace: serviceWebhookTestNamespace,
+			Operation: admissionv1.Create,
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+			Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+			Object:    runtime.RawExtension{Raw: raw},
 		},
 	}
 }
+
+func makeService(svcType corev1.ServiceType) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: serviceWebhookTestNamespace},
+		Spec:       corev1.ServiceSpec{Type: svcType},
+	}
+}
+
+var _ = Describe("ServiceWebhook", func() {
+	const (
+		nsName  = serviceWebhookTestNamespace
+		crqName = "svc-crq"
+	)
+	var (
+		engine *gin.Engine
+		labels = map[string]string{"team": "alpha"}
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		engine = gin.New()
+	})
+
+	Describe("NewServiceWebhook", func() {
+		It("constructs with all dependencies", func() {
+			client := newTestCRQClient()
+			h := NewServiceWebhook(client, zap.NewNop())
+			Expect(h).NotTo(BeNil())
+			Expect(h.crqClient).To(Equal(client))
+		})
+
+		It("uses a no-op logger when nil is passed", func() {
+			h := NewServiceWebhook(nil, nil)
+			Expect(h).NotTo(BeNil())
+			Expect(h.logger).NotTo(BeNil())
+		})
+	})
+
+	Describe("Handle (status-read path)", func() {
+		It("admits a ClusterIP service when under the services quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{usage.ResourceServices: quantity("5")},
+				quotav1alpha1.ResourceList{usage.ResourceServices: quantity("2")},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("1", makeService(corev1.ServiceTypeClusterIP)))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("denies a ClusterIP service when at the services quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{usage.ResourceServices: quantity("2")},
+				quotav1alpha1.ResourceList{usage.ResourceServices: quantity("2")},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("2", makeService(corev1.ServiceTypeClusterIP)))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("services limit exceeded"))
+		})
+
+		It("denies a LoadBalancer service when over the LB quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("10"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("0"),
+					usage.ResourceServicesLoadBalancers: quantity("1"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("3", makeService(corev1.ServiceTypeLoadBalancer)))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("services.loadbalancers limit exceeded"))
+		})
+
+		It("denies a NodePort service when over the NodePort quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:          quantity("10"),
+					usage.ResourceServicesNodePorts: quantity("0"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:          quantity("0"),
+					usage.ResourceServicesNodePorts: quantity("0"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("4", makeService(corev1.ServiceTypeNodePort)))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("services.nodeports limit exceeded"))
+		})
+
+		It("does not check subtype quotas for a ClusterIP service", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("10"),
+					usage.ResourceServicesLoadBalancers: quantity("0"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceServices:              quantity("0"),
+					usage.ResourceServicesLoadBalancers: quantity("0"),
+				},
+			)
+			h := NewServiceWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("5", makeService(corev1.ServiceTypeClusterIP)))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("admits when no CRQ matches the namespace", func() {
+			ns := makeNamespace(nsName, labels)
+			h := NewServiceWebhook(newTestCRQClient(ns), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("6", makeService(corev1.ServiceTypeClusterIP)))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("admits when the CRQ client is nil", func() {
+			h := NewServiceWebhook(nil, zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine,
+				newServiceReview("7", makeService(corev1.ServiceTypeClusterIP)))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("rejects DELETE as unsupported", func() {
+			h := NewServiceWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newServiceReview("8", makeService(corev1.ServiceTypeClusterIP))
+			review.Request.Operation = admissionv1.Delete
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Operation DELETE is not supported"))
+		})
+
+		It("denies a non-Service GVK", func() {
+			h := NewServiceWebhook(newTestCRQClient(), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			review := newServiceReview("9", makeService(corev1.ServiceTypeClusterIP))
+			review.Request.Kind = metav1.GroupVersionKind{Kind: "Pod"}
+			resp := sendWebhookRequest(engine, review)
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("Expected Service"))
+		})
+	})
+})

--- a/pkg/webhook/v1alpha1/webhook_handler.go
+++ b/pkg/webhook/v1alpha1/webhook_handler.go
@@ -131,15 +131,21 @@ func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate 
 // decodeAdmissionObject decodes raw bytes into obj, returning a 400-coded
 // statusError on failure.
 func decodeAdmissionObject(raw []byte, into runtime.Object, kind string) error {
-	if err := runtime.DecodeInto(
-		serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer(),
-		raw,
-		into,
-	); err != nil {
+	if err := runtime.DecodeInto(webhookDecoder, raw, into); err != nil {
 		return newStatusErrorf(http.StatusBadRequest, "Unable to decode %s object: %v", kind, err)
 	}
 	return nil
 }
+
+// Shared scheme + decoder for admission decoding. The universal deserializer
+// does not require types to be registered, so a single empty scheme is safe
+// to share across all webhooks and avoids per-request allocations.
+var (
+	webhookScheme  = runtime.NewScheme()
+	webhookDecoder = serializer.NewCodecFactory(webhookScheme).UniversalDeserializer()
+
+	oneQuantity = *resource.NewQuantity(1, resource.DecimalSI)
+)
 
 // unsupportedOperationError builds the standard 400 error for webhooks that only accept CREATE/UPDATE.
 func unsupportedOperationError(op admissionv1.Operation, resourceType string) error {

--- a/pkg/webhook/v1alpha1/webhook_handler.go
+++ b/pkg/webhook/v1alpha1/webhook_handler.go
@@ -14,18 +14,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
-	"github.com/powerhome/pac-quota-controller/pkg/metrics"
+	"k8s.io/apimachinery/pkg/types"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/namespace"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
+	"github.com/powerhome/pac-quota-controller/pkg/metrics"
 )
 
-// statusError carries an HTTP status code alongside an error message so callbacks
-// can signal client errors (e.g. decode failures, unsupported operations) vs
-// quota-violation denials, which use http.StatusForbidden by default.
+// statusError carries an HTTP status code so callbacks can distinguish client
+// errors (decode, unsupported op) from quota denials (default 403).
 type statusError struct {
 	code int
 	msg  string
@@ -48,15 +45,11 @@ type webhookConfig struct {
 	requireNamespace bool
 }
 
-// validateFn is the per-request callback invoked by runWebhook after all
-// structural checks pass. It is responsible for decoding the request body and
-// running the actual quota validation.
+// validateFn is the per-request callback invoked by runWebhook after structural checks.
 type validateFn func(ctx context.Context, req *admissionv1.AdmissionRequest) ([]string, error)
 
-// runWebhook is the single entry point used by every admission webhook handler.
-// It handles JSON binding, request shape validation, metrics, GVK checks and
-// response writing so that each concrete webhook only needs to provide a
-// validate callback.
+// runWebhook is the shared entry point for every admission handler: JSON
+// binding, request validation, metrics, GVK check, and response writing.
 func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate validateFn) {
 	var review admissionv1.AdmissionReview
 	if err := c.ShouldBindJSON(&review); err != nil {
@@ -135,9 +128,8 @@ func runWebhook(c *gin.Context, logger *zap.Logger, cfg webhookConfig, validate 
 	c.JSON(http.StatusOK, review)
 }
 
-// decodeAdmissionObject decodes raw bytes into the supplied object using the
-// universal deserializer, returning a 400-coded statusError on failure so
-// runWebhook surfaces the expected client-error response.
+// decodeAdmissionObject decodes raw bytes into obj, returning a 400-coded
+// statusError on failure.
 func decodeAdmissionObject(raw []byte, into runtime.Object, kind string) error {
 	if err := runtime.DecodeInto(
 		serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer(),
@@ -149,26 +141,21 @@ func decodeAdmissionObject(raw []byte, into runtime.Object, kind string) error {
 	return nil
 }
 
-// unsupportedOperationError builds the standard "operation not supported" error
-// for webhooks that only accept CREATE/UPDATE.
+// unsupportedOperationError builds the standard 400 error for webhooks that only accept CREATE/UPDATE.
 func unsupportedOperationError(op admissionv1.Operation, resourceType string) error {
 	return newStatusErrorf(http.StatusBadRequest, "Operation %s is not supported for %s", op, resourceType)
 }
 
-// validateAgainstCRQ is the shared "fetch namespace + delegate to the CRQ
-// validator" wrapper used by every namespaced webhook. It looks up the target
-// namespace, finds the CRQ that applies (if any), and verifies that adding
-// requested to the current cross-namespace usage stays within the configured
-// hard limit.
+// validateAgainstCRQ checks whether admitting `requested` of `resourceName` in
+// `namespaceName` would exceed the matching CRQ hard limit. It fails open
+// (admits + emits a metric) on any lookup or status-population miss.
 func validateAgainstCRQ(
 	ctx context.Context,
-	k8sClient kubernetes.Interface,
 	crqClient *quota.CRQClient,
 	logger *zap.Logger,
 	namespaceName string,
 	resourceName corev1.ResourceName,
 	requested resource.Quantity,
-	calculateCurrentUsage func(context.Context, string, corev1.ResourceName) (resource.Quantity, error),
 ) error {
 	correlationID := quota.GetCorrelationID(ctx)
 
@@ -178,12 +165,19 @@ func validateAgainstCRQ(
 			zap.String("namespace", namespaceName),
 			zap.String("resource", string(resourceName)),
 			zap.String("requested_quantity", requested.String()))
+		metrics.WebhookCRQLookup.WithLabelValues("no_client").Inc()
 		return nil
 	}
 
-	ns, err := k8sClient.CoreV1().Namespaces().Get(ctx, namespaceName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get namespace %s: %w", namespaceName, err)
+	ns := &corev1.Namespace{}
+	if err := crqClient.Client.Get(ctx, types.NamespacedName{Name: namespaceName}, ns); err != nil {
+		// Fail-open: transient cache miss must not block unrelated workloads.
+		logger.Error("Failed to get namespace - allowing operation",
+			zap.String("correlation_id", correlationID),
+			zap.String("namespace", namespaceName),
+			zap.Error(err))
+		metrics.WebhookCRQLookup.WithLabelValues("namespace_error").Inc()
+		return nil
 	}
 
 	logger.Debug("Starting CRQ validation",
@@ -195,13 +189,12 @@ func validateAgainstCRQ(
 
 	crq, err := crqClient.GetCRQByNamespace(ctx, ns)
 	if err != nil {
-		// TODO: currently fail-open on CRQ-lookup errors (log + admit) to
-		// avoid blocking unrelated workloads during transient API/informer issues.
-		// Revisit once we are confident the CRQ informer is reliably available;
+		// Fail-open on CRQ lookup errors; revisit when the CRQ informer is proven reliable.
 		logger.Error("Failed to get CRQ for namespace",
 			zap.String("correlation_id", correlationID),
 			zap.String("namespace", ns.Name),
 			zap.Error(err))
+		metrics.WebhookCRQLookup.WithLabelValues("crq_error").Inc()
 		return nil
 	}
 
@@ -210,27 +203,42 @@ func validateAgainstCRQ(
 			zap.String("correlation_id", correlationID),
 			zap.String("namespace", ns.Name),
 			zap.String("resource", string(resourceName)))
+		metrics.WebhookCRQLookup.WithLabelValues("not_found").Inc()
 		return nil
 	}
 
+	metrics.WebhookCRQLookup.WithLabelValues("found").Inc()
+	return validateCRQStatusUsage(crq, resourceName, requested, logger, correlationID)
+}
+
+// validateCRQStatusUsage compares an in-memory CRQ status against a request.
+// Split from validateAgainstCRQ so multi-resource handlers can resolve the
+// CRQ once. crq must be non-nil.
+func validateCRQStatusUsage(
+	crq *quotav1alpha1.ClusterResourceQuota,
+	resourceName corev1.ResourceName,
+	requested resource.Quantity,
+	logger *zap.Logger,
+	correlationID string,
+) error {
 	quotaLimit, exists := crq.Spec.Hard[resourceName]
 	if !exists {
 		logger.Debug("No quota limit defined for resource, allowing operation",
 			zap.String("correlation_id", correlationID),
-			zap.String("namespace", ns.Name),
 			zap.String("resource", string(resourceName)),
 			zap.String("crq_name", crq.Name))
 		return nil
 	}
 
-	currentUsage, err := calculateCRQCurrentUsage(ctx, k8sClient, crq, resourceName, calculateCurrentUsage, logger)
-	if err != nil {
-		logger.Error("Failed to calculate current usage across CRQ namespaces",
+	currentUsage, ok := crq.Status.Total.Used[resourceName]
+	if !ok {
+		// Fail-open: controller has not aggregated this resource yet (cold start / new key).
+		logger.Info("CRQ status missing usage for resource - allowing operation",
 			zap.String("correlation_id", correlationID),
-			zap.String("namespace", ns.Name),
 			zap.String("resource", string(resourceName)),
-			zap.Error(err))
-		return fmt.Errorf("failed to calculate current usage: %w", err)
+			zap.String("crq_name", crq.Name))
+		metrics.WebhookStatusMissing.WithLabelValues(crq.Name, string(resourceName)).Inc()
+		return nil
 	}
 
 	totalUsage := currentUsage.DeepCopy()
@@ -238,17 +246,16 @@ func validateAgainstCRQ(
 
 	logger.Debug("Quota validation check",
 		zap.String("correlation_id", correlationID),
-		zap.String("namespace", ns.Name),
 		zap.String("resource", string(resourceName)),
 		zap.String("current_usage", currentUsage.String()),
 		zap.String("requested_quantity", requested.String()),
 		zap.String("total_usage", totalUsage.String()),
-		zap.String("quota_limit", quotaLimit.String()))
+		zap.String("quota_limit", quotaLimit.String()),
+		zap.String("crq_name", crq.Name))
 
 	if totalUsage.Cmp(quotaLimit) > 0 {
 		logger.Info("Resource quota would be exceeded",
 			zap.String("correlation_id", correlationID),
-			zap.String("namespace", ns.Name),
 			zap.String("resource", string(resourceName)),
 			zap.String("current_usage", currentUsage.String()),
 			zap.String("requested_quantity", requested.String()),
@@ -265,57 +272,52 @@ func validateAgainstCRQ(
 
 	logger.Debug("CRQ validation passed",
 		zap.String("correlation_id", correlationID),
-		zap.String("namespace", ns.Name),
 		zap.String("resource", string(resourceName)),
 		zap.String("requested_quantity", requested.String()),
 		zap.String("crq_name", crq.Name))
 	return nil
 }
 
-// calculateCRQCurrentUsage sums the per-resource usage across every namespace
-// that matches the CRQ selector. It's the cross-namespace half of
-// validateAgainstCRQ.
-func calculateCRQCurrentUsage(
+// resolveCRQForNamespace returns the matching CRQ from the cache or nil on
+// any miss/error (fail-open). Lookup outcomes are tracked via WebhookCRQLookup.
+func resolveCRQForNamespace(
 	ctx context.Context,
-	kubernetesClient kubernetes.Interface,
-	crq *quotav1alpha1.ClusterResourceQuota,
-	resourceName corev1.ResourceName,
-	calculateCurrentUsage func(context.Context, string, corev1.ResourceName) (resource.Quantity, error),
+	crqClient *quota.CRQClient,
 	logger *zap.Logger,
-) (resource.Quantity, error) {
-	namespaceNames, err := namespace.GetSelectedNamespaces(ctx, kubernetesClient, crq)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("failed to get namespaces matching CRQ selector: %w", err)
+	namespaceName string,
+) *quotav1alpha1.ClusterResourceQuota {
+	correlationID := quota.GetCorrelationID(ctx)
+
+	if crqClient == nil {
+		metrics.WebhookCRQLookup.WithLabelValues("no_client").Inc()
+		return nil
 	}
 
-	logger.Debug("Calculating usage across CRQ namespaces",
-		zap.String("crq", crq.Name),
-		zap.String("resource", string(resourceName)),
-		zap.Strings("namespaces", namespaceNames))
-
-	totalUsage := resource.NewQuantity(0, resource.DecimalSI)
-	for _, namespaceName := range namespaceNames {
-		nsUsage, err := calculateCurrentUsage(ctx, namespaceName, resourceName)
-		if err != nil {
-			logger.Error("Failed to calculate usage for namespace",
-				zap.String("namespace", namespaceName),
-				zap.String("resource", string(resourceName)),
-				zap.Error(err))
-			return resource.Quantity{}, fmt.Errorf("failed to calculate usage for namespace %s: %w", namespaceName, err)
-		}
-		totalUsage.Add(nsUsage)
-
-		logger.Debug("Namespace usage calculated",
+	ns := &corev1.Namespace{}
+	if err := crqClient.Client.Get(ctx, types.NamespacedName{Name: namespaceName}, ns); err != nil {
+		logger.Error("Failed to get namespace - allowing operation",
+			zap.String("correlation_id", correlationID),
 			zap.String("namespace", namespaceName),
-			zap.String("resource", string(resourceName)),
-			zap.String("usage", nsUsage.String()))
+			zap.Error(err))
+		metrics.WebhookCRQLookup.WithLabelValues("namespace_error").Inc()
+		return nil
 	}
 
-	logger.Debug("Total CRQ usage calculated",
-		zap.String("crq", crq.Name),
-		zap.String("resource", string(resourceName)),
-		zap.String("total_usage", totalUsage.String()),
-		zap.Strings("namespaces", namespaceNames))
+	crq, err := crqClient.GetCRQByNamespace(ctx, ns)
+	if err != nil {
+		logger.Error("Failed to get CRQ for namespace - allowing operation",
+			zap.String("correlation_id", correlationID),
+			zap.String("namespace", ns.Name),
+			zap.Error(err))
+		metrics.WebhookCRQLookup.WithLabelValues("crq_error").Inc()
+		return nil
+	}
 
-	return *totalUsage, nil
+	if crq == nil {
+		metrics.WebhookCRQLookup.WithLabelValues("not_found").Inc()
+		return nil
+	}
+
+	metrics.WebhookCRQLookup.WithLabelValues("found").Inc()
+	return crq
 }

--- a/pkg/webhook/v1alpha1/webhook_handler_test.go
+++ b/pkg/webhook/v1alpha1/webhook_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 
@@ -14,20 +13,10 @@ import (
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
-	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
 )
 
 // postReview runs the engine and returns the parsed AdmissionReview and HTTP code.
@@ -45,79 +34,73 @@ var _ = Describe("runWebhook", func() {
 	var (
 		engine *gin.Engine
 		logger *zap.Logger
-		cfg    webhookConfig
 	)
 
 	BeforeEach(func() {
 		gin.SetMode(gin.TestMode)
 		engine = gin.New()
 		logger = zap.NewNop()
-		cfg = webhookConfig{
-			name:             "test",
-			expectedGVK:      &metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
-			requireNamespace: true,
-		}
 	})
 
-	mount := func(v validateFn) {
-		engine.POST("/webhook", func(c *gin.Context) { runWebhook(c, logger, cfg, v) })
-	}
-
-	It("returns 400 on malformed JSON body", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+	It("returns 400 on malformed JSON", func() {
+		engine.POST("/webhook", func(c *gin.Context) {
+			runWebhook(c, logger, webhookConfig{name: "t"},
+				func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+		})
 		code, _ := postReview(engine, []byte("{not-json"))
 		Expect(code).To(Equal(http.StatusBadRequest))
 	})
 
-	It("returns 400 when AdmissionReview.Request is nil", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+	It("returns 400 on missing request", func() {
+		engine.POST("/webhook", func(c *gin.Context) {
+			runWebhook(c, logger, webhookConfig{name: "t"},
+				func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+		})
 		body, _ := json.Marshal(admissionv1.AdmissionReview{})
 		code, _ := postReview(engine, body)
 		Expect(code).To(Equal(http.StatusBadRequest))
 	})
 
-	It("denies with templated namespace message when namespace required and empty", func() {
-		cfg.name = "objectcount"
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+	It("denies when namespace is required but empty", func() {
+		engine.POST("/webhook", func(c *gin.Context) {
+			runWebhook(c, logger, webhookConfig{name: "t", requireNamespace: true},
+				func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+		})
+		body, _ := json.Marshal(admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{UID: "1", Operation: admissionv1.Create},
+		})
+		code, resp := postReview(engine, body)
+		Expect(code).To(Equal(http.StatusOK))
+		Expect(resp.Response.Allowed).To(BeFalse())
+		Expect(resp.Response.Result.Message).To(ContainSubstring("Namespace is required"))
+	})
+
+	It("denies when GVK does not match", func() {
+		expected := metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+		engine.POST("/webhook", func(c *gin.Context) {
+			runWebhook(c, logger, webhookConfig{name: "t", expectedGVK: &expected},
+				func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+		})
 		body, _ := json.Marshal(admissionv1.AdmissionReview{
 			Request: &admissionv1.AdmissionRequest{
-				UID:       types.UID("u1"),
-				Operation: admissionv1.Create,
-				Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+				UID: "1", Operation: admissionv1.Create,
+				Kind: metav1.GroupVersionKind{Kind: "Service"},
 			},
 		})
 		code, resp := postReview(engine, body)
 		Expect(code).To(Equal(http.StatusOK))
 		Expect(resp.Response.Allowed).To(BeFalse())
-		Expect(resp.Response.Result.Message).To(ContainSubstring("Namespace is required for objectcount validation"))
-		Expect(resp.Response.Result.Code).To(Equal(int32(http.StatusBadRequest)))
+		Expect(resp.Response.Result.Message).To(ContainSubstring("Expected Pod"))
 	})
 
-	It("denies when AdmissionRequest.Kind does not match expectedGVK", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
-		body, _ := json.Marshal(admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				UID:       types.UID("u2"),
-				Namespace: "default",
-				Operation: admissionv1.Create,
-				Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
-			},
+	It("admits when the validate callback returns nil", func() {
+		engine.POST("/webhook", func(c *gin.Context) {
+			runWebhook(c, logger, webhookConfig{name: "t", requireNamespace: true},
+				func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
 		})
-		code, resp := postReview(engine, body)
-		Expect(code).To(Equal(http.StatusOK))
-		Expect(resp.Response.Allowed).To(BeFalse())
-		Expect(resp.Response.Result.Message).To(ContainSubstring("Expected Pod resource, got Service"))
-	})
-
-	It("skips GVK check when expectedGVK is nil", func() {
-		cfg.expectedGVK = nil
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
 		body, _ := json.Marshal(admissionv1.AdmissionReview{
 			Request: &admissionv1.AdmissionRequest{
-				UID:       types.UID("u3"),
-				Namespace: "default",
-				Operation: admissionv1.Create,
-				Kind:      metav1.GroupVersionKind{Kind: "AnythingGoes"},
+				UID: "1", Operation: admissionv1.Create, Namespace: "ns",
 			},
 		})
 		code, resp := postReview(engine, body)
@@ -125,357 +108,211 @@ var _ = Describe("runWebhook", func() {
 		Expect(resp.Response.Allowed).To(BeTrue())
 	})
 
-	It("allows cluster-scoped requests when requireNamespace is false", func() {
-		cfg.requireNamespace = false
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
+	It("denies with 403 by default on validate error", func() {
+		engine.POST("/webhook", func(c *gin.Context) {
+			runWebhook(c, logger, webhookConfig{name: "t", requireNamespace: true},
+				func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) {
+					return nil, newStatusErrorf(http.StatusForbidden, "no")
+				})
+		})
 		body, _ := json.Marshal(admissionv1.AdmissionReview{
 			Request: &admissionv1.AdmissionRequest{
-				UID:       types.UID("u4"),
-				Operation: admissionv1.Create,
-				Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+				UID: "1", Operation: admissionv1.Create, Namespace: "ns",
 			},
 		})
 		code, resp := postReview(engine, body)
 		Expect(code).To(Equal(http.StatusOK))
-		Expect(resp.Response.Allowed).To(BeTrue())
-	})
-
-	It("uses 403 forbidden by default when validate returns a plain error", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) {
-			return nil, errors.New("quota exceeded")
-		})
-		body, _ := json.Marshal(admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				UID: types.UID("u5"), Namespace: "default", Operation: admissionv1.Create,
-				Kind: metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
-			},
-		})
-		_, resp := postReview(engine, body)
 		Expect(resp.Response.Allowed).To(BeFalse())
 		Expect(resp.Response.Result.Code).To(Equal(int32(http.StatusForbidden)))
-		Expect(resp.Response.Result.Message).To(Equal("quota exceeded"))
-	})
-
-	It("honors statusError.code when validate returns one", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) {
-			return nil, newStatusErrorf(http.StatusBadRequest, "bad %s", "thing")
-		})
-		body, _ := json.Marshal(admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				UID: types.UID("u6"), Namespace: "default", Operation: admissionv1.Create,
-				Kind: metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
-			},
-		})
-		_, resp := postReview(engine, body)
-		Expect(resp.Response.Result.Code).To(Equal(int32(http.StatusBadRequest)))
-		Expect(resp.Response.Result.Message).To(Equal("bad thing"))
-	})
-
-	It("attaches warnings on success when validate returns them", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) {
-			return []string{"watch out"}, nil
-		})
-		body, _ := json.Marshal(admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				UID: types.UID("u7"), Namespace: "default", Operation: admissionv1.Create,
-				Kind: metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
-			},
-		})
-		_, resp := postReview(engine, body)
-		Expect(resp.Response.Allowed).To(BeTrue())
-		Expect(resp.Response.Warnings).To(Equal([]string{"watch out"}))
-	})
-
-	It("propagates the AdmissionRequest UID to the response", func() {
-		mount(func(context.Context, *admissionv1.AdmissionRequest) ([]string, error) { return nil, nil })
-		body, _ := json.Marshal(admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				UID: types.UID("uid-echo"), Namespace: "default", Operation: admissionv1.Create,
-				Kind: metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
-			},
-		})
-		_, resp := postReview(engine, body)
-		Expect(resp.Response.UID).To(Equal(types.UID("uid-echo")))
 	})
 })
 
 var _ = Describe("decodeAdmissionObject", func() {
-	It("returns a 400 statusError when raw bytes are invalid", func() {
+	It("returns a 400-coded statusError on bad bytes", func() {
 		var pod corev1.Pod
 		err := decodeAdmissionObject([]byte("not-json"), &pod, "Pod")
 		Expect(err).To(HaveOccurred())
 		se, ok := err.(*statusError)
 		Expect(ok).To(BeTrue())
 		Expect(se.code).To(Equal(http.StatusBadRequest))
-		Expect(se.Error()).To(ContainSubstring("Unable to decode Pod object"))
-	})
-
-	It("populates the target object on valid input", func() {
-		raw, _ := json.Marshal(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}})
-		var pod corev1.Pod
-		Expect(decodeAdmissionObject(raw, &pod, "Pod")).To(Succeed())
-		Expect(pod.Name).To(Equal("p"))
 	})
 })
 
 var _ = Describe("unsupportedOperationError", func() {
-	It("renders a 400 statusError mentioning op and resource", func() {
+	It("returns 400 with a clear message", func() {
 		err := unsupportedOperationError(admissionv1.Delete, "Pod")
-		se, ok := err.(*statusError)
-		Expect(ok).To(BeTrue())
-		Expect(se.code).To(Equal(http.StatusBadRequest))
-		Expect(se.Error()).To(Equal("Operation DELETE is not supported for Pod"))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Operation DELETE is not supported"))
 	})
 })
 
-var _ = Describe("validateAgainstCRQ", func() {
+var _ = Describe("validateAgainstCRQ (status-read path)", func() {
 	var (
-		ctx        context.Context
-		fakeClient *fake.Clientset
-		logger     *zap.Logger
-		crqClient  *quota.CRQClient
-		ns         *corev1.Namespace
+		ctx     context.Context
+		logger  *zap.Logger
+		nsLabel = map[string]string{"team": "alpha"}
 	)
-
 	const nsName = "vh-ns"
 
 	BeforeEach(func() {
 		ctx = context.Background()
 		logger = zap.NewNop()
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   nsName,
-				Labels: map[string]string{"team": "alpha"},
-			},
-		}
-		fakeClient = fake.NewSimpleClientset(ns)
 	})
 
-	newCRQClient := func(objs ...runtime.Object) *quota.CRQClient {
-		scheme := runtime.NewScheme()
-		_ = quotav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		cl := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
-		return quota.NewCRQClient(cl, logger)
-	}
-
-	calc := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
-		return *resource.NewQuantity(0, resource.DecimalSI), nil
-	}
-
-	It("returns nil when crqClient is nil (validation skipped)", func() {
-		err := validateAgainstCRQ(ctx, fakeClient, nil, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), calc)
+	It("admits when crqClient is nil", func() {
+		err := validateAgainstCRQ(ctx, nil, logger, nsName, corev1.ResourceCPU, quantity("1"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("returns an error when the namespace lookup fails", func() {
-		crqClient = newCRQClient()
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			"missing", corev1.ResourceCPU, resource.MustParse("1"), calc)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get namespace missing"))
-	})
-
-	It("swallows CRQ-lookup errors and allows the operation", func() {
-		// Use a CRQ client whose underlying List call returns an error.
-		scheme := runtime.NewScheme()
-		_ = quotav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		cl := ctrlclientfake.NewClientBuilder().
-			WithScheme(scheme).
-			WithInterceptorFuncs(interceptListError()).
-			Build()
-		crqClient = quota.NewCRQClient(cl, logger)
-
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), calc)
+	It("admits (fail-open) when namespace lookup fails", func() {
+		// CRQ client exists but namespace is absent: Get returns NotFound.
+		client := newTestCRQClient()
+		err := validateAgainstCRQ(ctx, client, logger, "missing", corev1.ResourceCPU, quantity("1"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("allows when no CRQ applies to the namespace", func() {
-		crqClient = newCRQClient() // no CRQ objects
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), calc)
+	It("admits (fail-open) when CRQ list errors out", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		client := newTestCRQClientWithListError(ns)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("1"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("allows when CRQ matches but the resource has no hard limit", func() {
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq-other"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"team": "alpha"},
-				},
-				Hard: quotav1alpha1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			},
-		}
-		crqClient = newCRQClient(crq)
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), calc)
+	It("admits when no CRQ matches the namespace", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		client := newTestCRQClient(ns)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("1"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("denies when total usage exceeds the hard quota limit", func() {
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq-cpu"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"team": "alpha"},
-				},
-				Hard: quotav1alpha1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("2"),
-				},
-			},
-		}
-		crqClient = newCRQClient(crq)
-		usage := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
-			return resource.MustParse("2"), nil
-		}
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), usage)
+	It("admits when the CRQ has no hard limit for the resource", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		crq := makeCRQ("crq", nsLabel,
+			quotav1alpha1.ResourceList{corev1.ResourceMemory: quantity("1Gi")},
+			quotav1alpha1.ResourceList{corev1.ResourceMemory: quantity("0")},
+		)
+		client := newTestCRQClient(ns, crq)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("1"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("admits (fail-open) when the status has no usage value for the resource", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		crq := makeCRQ("crq", nsLabel,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+			nil,
+		)
+		client := newTestCRQClient(ns, crq)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("1"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("denies when status.used + requested would exceed the hard limit", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		crq := makeCRQ("crq-cpu", nsLabel,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+		)
+		client := newTestCRQClient(ns, crq)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("1"))
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("ClusterResourceQuota 'crq-cpu' cpu limit exceeded"))
 	})
 
-	It("allows when total usage stays at or under the hard limit", func() {
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq-cpu"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"team": "alpha"},
-				},
-				Hard: quotav1alpha1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("5"),
-				},
-			},
-		}
-		crqClient = newCRQClient(crq)
-		usage := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
-			return resource.MustParse("2"), nil
-		}
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), usage)
+	It("admits when status.used + requested stays within the hard limit", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		crq := makeCRQ("crq-cpu", nsLabel,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("5")},
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+		)
+		client := newTestCRQClient(ns, crq)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("3"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("wraps the underlying error when the usage calculator fails", func() {
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq-cpu"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"team": "alpha"},
-				},
-				Hard: quotav1alpha1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("5"),
-				},
-			},
-		}
-		crqClient = newCRQClient(crq)
-		failing := func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
-			return resource.Quantity{}, errors.New("boom")
-		}
-		err := validateAgainstCRQ(ctx, fakeClient, crqClient, logger,
-			nsName, corev1.ResourceCPU, resource.MustParse("1"), failing)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to calculate current usage"))
-		Expect(err.Error()).To(ContainSubstring("boom"))
+	It("admits when total exactly equals the hard limit", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		crq := makeCRQ("crq-cpu", nsLabel,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("5")},
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("4")},
+		)
+		client := newTestCRQClient(ns, crq)
+		err := validateAgainstCRQ(ctx, client, logger, nsName, corev1.ResourceCPU, quantity("1"))
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 
-var _ = Describe("calculateCRQCurrentUsage", func() {
+var _ = Describe("resolveCRQForNamespace", func() {
 	var (
-		ctx    context.Context
-		logger *zap.Logger
+		ctx     context.Context
+		logger  *zap.Logger
+		nsLabel = map[string]string{"team": "alpha"}
 	)
+	const nsName = "vh-ns"
 
 	BeforeEach(func() {
 		ctx = context.Background()
 		logger = zap.NewNop()
 	})
 
-	It("returns 0 when the CRQ selector matches no namespaces", func() {
-		fakeClient := fake.NewSimpleClientset()
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k": "v"}},
-			},
-		}
-		total, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(context.Context, string, corev1.ResourceName) (resource.Quantity, error) {
-				return resource.MustParse("99"), nil
-			}, logger)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(total.Value()).To(BeZero())
+	It("returns nil when client is nil", func() {
+		crq := resolveCRQForNamespace(ctx, nil, logger, nsName)
+		Expect(crq).To(BeNil())
 	})
 
-	It("sums usage across every selected namespace", func() {
-		fakeClient := fake.NewSimpleClientset(
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "a", Labels: map[string]string{"t": "x"}}},
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "b", Labels: map[string]string{"t": "x"}}},
+	It("returns nil (fail-open) when namespace cannot be fetched", func() {
+		client := newTestCRQClient()
+		crq := resolveCRQForNamespace(ctx, client, logger, "missing")
+		Expect(crq).To(BeNil())
+	})
+
+	It("returns the matching CRQ when found", func() {
+		ns := makeNamespace(nsName, nsLabel)
+		want := makeCRQ("crq", nsLabel,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("1")},
 		)
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"t": "x"}},
-			},
-		}
-		total, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(_ context.Context, _ string, _ corev1.ResourceName) (resource.Quantity, error) {
-				return resource.MustParse("3"), nil
-			}, logger)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(total.String()).To(Equal("6"))
-	})
-
-	It("returns an error if any per-namespace calculator call fails", func() {
-		fakeClient := fake.NewSimpleClientset(
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "a", Labels: map[string]string{"t": "x"}}},
-		)
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"t": "x"}},
-			},
-		}
-		_, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(context.Context, string, corev1.ResourceName) (resource.Quantity, error) {
-				return resource.Quantity{}, errors.New("calc boom")
-			}, logger)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to calculate usage for namespace a"))
-	})
-
-	It("returns an error when the namespace selector lookup itself fails", func() {
-		fakeClient := fake.NewSimpleClientset()
-		fakeClient.PrependReactor("list", "namespaces",
-			func(k8stesting.Action) (bool, runtime.Object, error) {
-				return true, nil, errors.New("list boom")
-			})
-		crq := &quotav1alpha1.ClusterResourceQuota{
-			ObjectMeta: metav1.ObjectMeta{Name: "crq"},
-			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
-				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"t": "x"}},
-			},
-		}
-		_, err := calculateCRQCurrentUsage(ctx, fakeClient, crq, corev1.ResourceCPU,
-			func(context.Context, string, corev1.ResourceName) (resource.Quantity, error) {
-				return resource.Quantity{}, nil
-			}, logger)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get namespaces matching CRQ selector"))
+		client := newTestCRQClient(ns, want)
+		got := resolveCRQForNamespace(ctx, client, logger, nsName)
+		Expect(got).NotTo(BeNil())
+		Expect(got.Name).To(Equal("crq"))
 	})
 })
 
-// interceptListError causes any controller-runtime List call on the fake
-// client to fail, exercising the error branch in CRQClient.GetCRQByNamespace.
-func interceptListError() interceptor.Funcs {
-	return interceptor.Funcs{
-		List: func(_ context.Context, _ ctrlclient.WithWatch, _ ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
-			return apierrors.NewServerTimeout(schema.GroupResource{Resource: "clusterresourcequotas"}, "list", 1)
-		},
-	}
-}
+var _ = Describe("validateCRQStatusUsage", func() {
+	logger := zap.NewNop()
+
+	It("returns nil when the resource is not in spec.hard", func() {
+		crq := makeCRQ("c", nil,
+			quotav1alpha1.ResourceList{corev1.ResourceMemory: quantity("1Gi")},
+			quotav1alpha1.ResourceList{corev1.ResourceMemory: quantity("0")},
+		)
+		Expect(validateCRQStatusUsage(crq, corev1.ResourceCPU, quantity("1"), logger, "")).To(Succeed())
+	})
+
+	It("returns nil (fail-open) when status is missing the resource", func() {
+		crq := makeCRQ("c", nil,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+			quotav1alpha1.ResourceList{corev1.ResourceMemory: quantity("0")},
+		)
+		Expect(validateCRQStatusUsage(crq, corev1.ResourceCPU, quantity("1"), logger, "")).To(Succeed())
+	})
+
+	It("returns an error when over the hard limit", func() {
+		crq := makeCRQ("c", nil,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("2")},
+		)
+		err := validateCRQStatusUsage(crq, corev1.ResourceCPU, quantity("1"), logger, "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("limit exceeded"))
+	})
+
+	It("returns nil when zero usage + requested exactly equals limit", func() {
+		crq := makeCRQ("c", nil,
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: quantity("1")},
+			quotav1alpha1.ResourceList{corev1.ResourceCPU: *resource.NewQuantity(0, resource.DecimalSI)},
+		)
+		Expect(validateCRQStatusUsage(crq, corev1.ResourceCPU, quantity("1"), logger, "")).To(Succeed())
+	})
+})

--- a/pkg/webhook/v1alpha1/webhook_helpers_test.go
+++ b/pkg/webhook/v1alpha1/webhook_helpers_test.go
@@ -2,17 +2,30 @@ package v1alpha1
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
+	"github.com/powerhome/pac-quota-controller/pkg/logger"
 )
 
-// sendWebhookRequest drives the gin engine through an HTTP round-trip and
-// decodes the resulting AdmissionReview. Test-only.
+var errFakeList = errors.New("fake list error")
+
+// sendWebhookRequest drives the gin engine via HTTP round-trip and decodes the AdmissionReview.
 func sendWebhookRequest(engine *gin.Engine, admissionReview *admissionv1.AdmissionReview) *admissionv1.AdmissionReview {
 	body, _ := json.Marshal(admissionReview)
 	req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer(body))
@@ -34,3 +47,65 @@ func sendWebhookRequest(engine *gin.Engine, admissionReview *admissionv1.Admissi
 	}
 	return &response
 }
+
+// testScheme returns a scheme registered with CRQ + corev1.
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = quotav1alpha1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+// newTestCRQClient builds an in-memory CRQClient seeded with the given objects.
+func newTestCRQClient(objs ...ctrlclient.Object) *quota.CRQClient {
+	cl := ctrlclientfake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		Build()
+	return quota.NewCRQClient(cl, logger.L())
+}
+
+// newTestCRQClientWithListError returns a CRQClient whose List operations fail (exercises CRQ-lookup fail-open).
+func newTestCRQClientWithListError(seed ...ctrlclient.Object) *quota.CRQClient {
+	cl := ctrlclientfake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(seed...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ ctrlclient.WithWatch, _ ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				return errFakeList
+			},
+		}).
+		Build()
+	return quota.NewCRQClient(cl, logger.L())
+}
+
+// makeNamespace returns a Namespace object with the requested labels.
+func makeNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+// makeCRQ returns a CRQ that selects namespaces by labels and seeds Spec.Hard / Status.Total.Used.
+func makeCRQ(name string, selectorLabels map[string]string,
+	hard, used quotav1alpha1.ResourceList) *quotav1alpha1.ClusterResourceQuota {
+	return &quotav1alpha1.ClusterResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+			Hard:              hard,
+		},
+		Status: quotav1alpha1.ClusterResourceQuotaStatus{
+			Total: quotav1alpha1.ResourceQuotaStatus{
+				Hard: hard,
+				Used: used,
+			},
+		},
+	}
+}
+
+// quantity is a one-liner for resource.MustParse.
+func quantity(s string) resource.Quantity { return resource.MustParse(s) }

--- a/test/e2e/objectcount_webhook_test.go
+++ b/test/e2e/objectcount_webhook_test.go
@@ -95,6 +95,10 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 				err := k8sClient.Create(ctx, cm)
 				Expect(err).ToNot(HaveOccurred(), "ConfigMap creation up to quota should be allowed")
 			}
+			// Wait until the controller reports usage == quota so the webhook can see it.
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "configmaps", resource.MustParse("3"),
+			)).To(Succeed())
 			// Attempt to create one more, should fail
 			cmName := testutils.GenerateResourceName("cm-over-quota-" + testSuffix + "-extra")
 			cm := &corev1.ConfigMap{
@@ -130,6 +134,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			}
 			err := k8sClient.Create(ctx, secret)
 			Expect(err).ToNot(HaveOccurred(), "Secret creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "secrets", resource.MustParse("1"),
+			)).To(Succeed())
 			// Attempt to create one more, should fail
 			secretNameExtra := testutils.GenerateResourceName("secret-over-quota-" + testSuffix + "-extra")
 			secretExtra := &corev1.Secret{
@@ -153,6 +160,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			rc := testutils.NewReplicationController(rcName, testNamespace, 1)
 			err := k8sClient.Create(ctx, rc)
 			Expect(err).ToNot(HaveOccurred(), "ReplicationController creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "replicationcontrollers", resource.MustParse("1"),
+			)).To(Succeed())
 			rcNameExtra := testutils.GenerateResourceName("rc-over-quota-" + testSuffix + "-extra")
 			rcExtra := testutils.NewReplicationController(rcNameExtra, testNamespace, 1)
 			err = k8sClient.Create(ctx, rcExtra)
@@ -169,6 +179,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			dep := testutils.NewDeployment(depName, testNamespace, 1)
 			err := k8sClient.Create(ctx, dep)
 			Expect(err).ToNot(HaveOccurred(), "Deployment creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "deployments.apps", resource.MustParse("1"),
+			)).To(Succeed())
 			depNameExtra := testutils.GenerateResourceName("dep-over-quota-" + testSuffix + "-extra")
 			depExtra := testutils.NewDeployment(depNameExtra, testNamespace, 1)
 			err = k8sClient.Create(ctx, depExtra)
@@ -185,6 +198,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			ss := testutils.NewStatefulSet(ssName, testNamespace, 1)
 			err := k8sClient.Create(ctx, ss)
 			Expect(err).ToNot(HaveOccurred(), "StatefulSet creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "statefulsets.apps", resource.MustParse("1"),
+			)).To(Succeed())
 			ssNameExtra := testutils.GenerateResourceName("ss-over-quota-" + testSuffix + "-extra")
 			ssExtra := testutils.NewStatefulSet(ssNameExtra, testNamespace, 1)
 			err = k8sClient.Create(ctx, ssExtra)
@@ -201,6 +217,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			ds := testutils.NewDaemonSet(dsName, testNamespace)
 			err := k8sClient.Create(ctx, ds)
 			Expect(err).ToNot(HaveOccurred(), "DaemonSet creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "daemonsets.apps", resource.MustParse("1"),
+			)).To(Succeed())
 			dsNameExtra := testutils.GenerateResourceName("ds-over-quota-" + testSuffix + "-extra")
 			dsExtra := testutils.NewDaemonSet(dsNameExtra, testNamespace)
 			err = k8sClient.Create(ctx, dsExtra)
@@ -221,6 +240,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			limits := corev1.ResourceList{}
 			_, err := testutils.CreateJob(ctx, k8sClient, testNamespace, jobName, command, requests, limits)
 			Expect(err).ToNot(HaveOccurred(), "Job creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "jobs.batch", resource.MustParse("1"),
+			)).To(Succeed())
 			jobNameExtra := testutils.GenerateResourceName("job-over-quota-" + testSuffix + "-extra")
 			_, err = testutils.CreateJob(ctx, k8sClient, testNamespace, jobNameExtra, command, requests, limits)
 			Expect(err).To(HaveOccurred(), "Job creation over quota should be denied")
@@ -236,6 +258,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			cj := testutils.NewCronJob(cjName, testNamespace)
 			err := k8sClient.Create(ctx, cj)
 			Expect(err).ToNot(HaveOccurred(), "CronJob creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "cronjobs.batch", resource.MustParse("1"),
+			)).To(Succeed())
 			cjNameExtra := testutils.GenerateResourceName("cj-over-quota-" + testSuffix + "-extra")
 			cjExtra := testutils.NewCronJob(cjNameExtra, testNamespace)
 			err = k8sClient.Create(ctx, cjExtra)
@@ -252,6 +277,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			hpa := testutils.NewHPA(hpaName, testNamespace)
 			err := k8sClient.Create(ctx, hpa)
 			Expect(err).ToNot(HaveOccurred(), "HPA creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "horizontalpodautoscalers.autoscaling", resource.MustParse("1"),
+			)).To(Succeed())
 			hpaNameExtra := testutils.GenerateResourceName("hpa-over-quota-" + testSuffix + "-extra")
 			hpaExtra := testutils.NewHPA(hpaNameExtra, testNamespace)
 			err = k8sClient.Create(ctx, hpaExtra)
@@ -268,6 +296,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			ing := testutils.NewIngress(ingName, testNamespace)
 			err := k8sClient.Create(ctx, ing)
 			Expect(err).ToNot(HaveOccurred(), "Ingress creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "ingresses.networking.k8s.io", resource.MustParse("1"),
+			)).To(Succeed())
 			ingNameExtra := testutils.GenerateResourceName("ing-over-quota-" + testSuffix + "-extra")
 			ingExtra := testutils.NewIngress(ingNameExtra, testNamespace)
 			err = k8sClient.Create(ctx, ingExtra)
@@ -374,6 +405,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 				err := k8sClient.Create(ctx, cm)
 				Expect(err).ToNot(HaveOccurred(), "ConfigMap creation up to quota should be allowed")
 			}
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "configmaps", resource.MustParse("3"),
+			)).To(Succeed())
 			cmExtra := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testutils.GenerateResourceName("cm-mixed-over-" + testSuffix + "-extra"),
@@ -390,6 +424,9 @@ var _ = Describe("ClusterResourceQuota Object Count Webhook E2E", func() {
 			}
 			err = k8sClient.Create(ctx, secret)
 			Expect(err).ToNot(HaveOccurred(), "Secret creation up to quota should be allowed")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "secrets", resource.MustParse("1"),
+			)).To(Succeed())
 			secretExtra := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testutils.GenerateResourceName("secret-mixed-over-" + testSuffix + "-extra"),

--- a/test/e2e/pod_webhook_test.go
+++ b/test/e2e/pod_webhook_test.go
@@ -83,6 +83,9 @@ var _ = Describe("Pod Admission Webhook Tests", func() {
 		})
 
 		It("should deny pod creation when it would exceed CPU limits", func() {
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourceRequestsCPU, resource.MustParse("0"),
+			)).To(Succeed())
 			_, err := testutils.CreatePod(
 				ctx,
 				k8sClient,
@@ -126,6 +129,9 @@ var _ = Describe("Pod Admission Webhook Tests", func() {
 		})
 
 		It("should deny pod creation with init containers exceeding limits", func() {
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourceRequestsCPU, resource.MustParse("0"),
+			)).To(Succeed())
 			_, err := testutils.CreatePodWithContainers(
 				ctx, k8sClient, testNamespace, "test-pod-init-container-"+testSuffix,
 				[]corev1.Container{
@@ -526,6 +532,9 @@ var _ = Describe("Pod Admission Webhook Tests", func() {
 					},
 				}, nil)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourcePods, resource.MustParse("2"),
+			)).To(Succeed())
 			// Create third pod - should fail
 			_, err = testutils.CreatePodWithContainers(
 				ctx, k8sClient, testNamespace, testutils.GenerateResourceName("test-pod-3"),

--- a/test/e2e/pod_webhook_test.go
+++ b/test/e2e/pod_webhook_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Pod Admission Webhook Tests", func() {
 				if fresh.Labels == nil {
 					fresh.Labels = map[string]string{}
 				}
-				fresh.Labels["updated"] = "true"
+				fresh.Labels["updated"] = "yes"
 				return k8sClient.Update(ctx, &fresh)
 			}, 30*time.Second, 500*time.Millisecond).Should(Succeed())
 		})

--- a/test/e2e/pod_webhook_test.go
+++ b/test/e2e/pod_webhook_test.go
@@ -224,76 +224,36 @@ var _ = Describe("Pod Admission Webhook Tests", func() {
 	})
 
 	Context("Pod Update Webhook", func() {
-		It("should deny pod updates that would exceed limits", func() {
-			pod, err := testutils.CreatePod(
-				ctx,
-				k8sClient,
-				testNamespace,
-				"test-pod-"+testSuffix,
-				corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("10m"),
-				}, nil)
+		It("should allow metadata updates when pod count quota is at the limit", func() {
+			// Fill pod count quota (2).
+			pod1, err := testutils.CreatePod(
+				ctx, k8sClient, testNamespace, "test-pod-update-1-"+testSuffix,
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m")}, nil)
 			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func() {
-				_ = k8sClient.Delete(ctx, pod)
-			})
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pod1) })
 
-			pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("200m") // Exceeds limit
-			Expect(k8sClient.Update(ctx, pod)).ToNot(Succeed())
-		})
-
-		It("should deny updates to pods with multiple containers exceeding limits", func() {
-			pod, err := testutils.CreatePod(
-				ctx,
-				k8sClient,
-				testNamespace,
-				"test-pod-update-multi-container-"+testSuffix,
-				corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("10m"),
-				},
-				corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("10m"),
-				})
+			pod2, err := testutils.CreatePod(
+				ctx, k8sClient, testNamespace, "test-pod-update-2-"+testSuffix,
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m")}, nil)
 			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func() {
-				_ = k8sClient.Delete(ctx, pod)
-			})
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pod2) })
 
-			pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("200m") // Exceeds limit
-			Expect(k8sClient.Update(ctx, pod)).ToNot(Succeed())
-		})
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourcePods, resource.MustParse("2"),
+			)).To(Succeed())
 
-		It("should deny updates to pods with init containers exceeding limits", func() {
-			pod, err := testutils.CreatePodWithContainers(
-				ctx, k8sClient, testNamespace, "test-pod-update-init-container-"+testSuffix,
-				[]corev1.Container{
-					{
-						Name:  "main-container",
-						Image: "nginx:latest",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("30m"),
-							},
-						},
-					},
-				}, []corev1.Container{
-					{
-						Name:  "init-container",
-						Image: "nginx:latest",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("50m"),
-							},
-						},
-					},
-				})
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func() {
-				_ = k8sClient.Delete(ctx, pod)
-			})
-
-			pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("300m") // Exceeds limit
-			Expect(k8sClient.Update(ctx, pod)).ToNot(Succeed())
+			// Re-fetch and retry on conflict; kubelet keeps updating pod status concurrently.
+			Eventually(func() error {
+				var fresh corev1.Pod
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod1.Name, Namespace: pod1.Namespace}, &fresh); err != nil {
+					return err
+				}
+				if fresh.Labels == nil {
+					fresh.Labels = map[string]string{}
+				}
+				fresh.Labels["updated"] = "true"
+				return k8sClient.Update(ctx, &fresh)
+			}, 30*time.Second, 500*time.Millisecond).Should(Succeed())
 		})
 	})
 

--- a/test/e2e/pvc_webhook_test.go
+++ b/test/e2e/pvc_webhook_test.go
@@ -88,18 +88,10 @@ var _ = Describe("PVC Webhook E2E Tests", func() {
 			_, err := testutils.CreatePVC(ctx, k8sClient, ns.Name, "first-pvc", "1.5Gi", nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Wait for the controller to update the status
-			Eventually(func() bool {
-				reconciledCRQ := &quotav1alpha1.ClusterResourceQuota{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: crq.Name}, reconciledCRQ); err != nil {
-					return false
-				}
-				// Check if usage has been updated
-				if used, exists := reconciledCRQ.Status.Total.Used[corev1.ResourceRequestsStorage]; exists {
-					return !used.IsZero()
-				}
-				return false
-			}, timeout, interval).Should(BeTrue())
+			// Wait for the controller to publish the new aggregated usage so the webhook can read it.
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourceRequestsStorage, resource.MustParse("1.5Gi"),
+			)).To(Succeed())
 
 			// Now try to create another PVC that would exceed the quota
 			_, err = testutils.CreatePVC(ctx, k8sClient, ns.Name, "second-pvc-blocked", "1Gi", nil)
@@ -142,6 +134,11 @@ var _ = Describe("PVC Webhook E2E Tests", func() {
 				}, pvc1)
 			}, timeout, interval).Should(Succeed())
 
+			// Wait for controller to publish aggregated usage so the webhook reads up-to-date data.
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourceRequestsStorage, resource.MustParse("500Mi"),
+			)).To(Succeed())
+
 			// Try to create another PVC that would exceed the 2Gi quota (500Mi + 2Gi = 2.5Gi > 2Gi)
 			pvc2, err := testutils.CreatePVC(ctx, k8sClient, ns.Name, "test-pvc-large", "2Gi", nil)
 			Expect(err).To(HaveOccurred())
@@ -180,6 +177,11 @@ var _ = Describe("PVC Webhook E2E Tests", func() {
 			// Create second PVC - should allow
 			_, err = testutils.CreatePVC(ctx, k8sClient, ns.Name, testutils.GenerateResourceName("test-pvc-2"), "1Gi", nil)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Wait until the controller reports 2 PVCs used so the webhook sees the fresh value.
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, corev1.ResourcePersistentVolumeClaims, resource.MustParse("2"),
+			)).To(Succeed())
 
 			// Create third PVC - should fail
 			_, err = testutils.CreatePVC(ctx, k8sClient, ns.Name, testutils.GenerateResourceName("test-pvc-3"), "1Gi", nil)

--- a/test/e2e/service_webhook_test.go
+++ b/test/e2e/service_webhook_test.go
@@ -289,5 +289,33 @@ var _ = Describe("Service Quota Webhook", func() {
 			err := k8sClient.Update(ctx, &fetched)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should allow metadata updates to an existing LB service when LB quota is at the limit", func() {
+			lbService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lb-meta-update-" + testSuffix,
+					Namespace: testNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, lbService)).To(Succeed())
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "services.loadbalancers", resource.MustParse("1"),
+			)).To(Succeed())
+
+			var fetched corev1.Service
+			Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
+				Name:      lbService.Name,
+				Namespace: testNamespace,
+			}, &fetched)).To(Succeed())
+			if fetched.Labels == nil {
+				fetched.Labels = map[string]string{}
+			}
+			fetched.Labels["updated"] = "yes"
+			Expect(k8sClient.Update(ctx, &fetched)).To(Succeed())
+		})
 	})
 })

--- a/test/e2e/service_webhook_test.go
+++ b/test/e2e/service_webhook_test.go
@@ -118,6 +118,9 @@ var _ = Describe("Service Quota Webhook", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, service)).To(Succeed())
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "services.nodeports", resource.MustParse("1"),
+			)).To(Succeed())
 			// Second NodePort service should be denied
 			service2 := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -161,6 +164,9 @@ var _ = Describe("Service Quota Webhook", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, service)).To(Succeed())
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "services.loadbalancers", resource.MustParse("1"),
+			)).To(Succeed())
 			// Second LoadBalancer service should be denied
 			service2 := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -264,6 +270,9 @@ var _ = Describe("Service Quota Webhook", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, lbService)).To(Succeed())
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, testCRQName, "services.loadbalancers", resource.MustParse("1"),
+			)).To(Succeed())
 			// Try to update the ClusterIP service to LoadBalancer (should fail)
 			var fetched corev1.Service
 			Expect(

--- a/test/e2e/storage_class_quota_test.go
+++ b/test/e2e/storage_class_quota_test.go
@@ -136,6 +136,13 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			pvc2 := createTestPVC("fast-pvc-2", testNamespace, storageClassFast, "2Gi")
 			Expect(k8sClient.Create(ctx, pvc2)).To(Succeed(), "Should allow second fast SSD PVC within limits")
 
+			By("Waiting for controller to publish fast storage usage")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName,
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.storage", storageClassFast)),
+				resource.MustParse("4Gi"),
+			)).To(Succeed())
+
 			By("Trying to create fast SSD PVC that exceeds storage quota (should fail)")
 			pvc3 := createTestPVC("fast-pvc-3", testNamespace, storageClassFast, "2Gi") // Total would be 6Gi > 5Gi limit
 			err := k8sClient.Create(ctx, pvc3)
@@ -148,6 +155,13 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			By("Creating third fast SSD PVC within both storage and count limits")
 			pvc4 := createTestPVC("fast-pvc-4", testNamespace, storageClassFast, "500Mi") // Within storage but count would be 3
 			Expect(k8sClient.Create(ctx, pvc4)).To(Succeed(), "Should allow third fast SSD PVC within both limits")
+
+			By("Waiting for controller to publish fast PVC count usage")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName,
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClassFast)),
+				resource.MustParse("3"),
+			)).To(Succeed())
 
 			By("Trying to create fast SSD PVC that exceeds count quota (should fail)")
 			pvc5 := createTestPVC("fast-pvc-5", testNamespace, storageClassFast, "100Mi") // Count would be 4 > 3 limit
@@ -165,6 +179,13 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			By("Creating second slow HDD PVC within limits")
 			slowPVC2 := createTestPVC("slow-pvc-2", testNamespace, storageClassSlow, "1Gi")
 			Expect(k8sClient.Create(ctx, slowPVC2)).To(Succeed(), "Should allow second slow HDD PVC within limits")
+
+			By("Waiting for controller to publish slow PVC count usage")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName,
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClassSlow)),
+				resource.MustParse("2"),
+			)).To(Succeed())
 
 			By("Trying to create slow HDD PVC that exceeds count quota (should fail)")
 			slowPVC3 := createTestPVC("slow-pvc-3", testNamespace, storageClassSlow, "500Mi") // Count would be 3 > 2 limit
@@ -241,6 +262,13 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			fastPVC3 := createTestPVC("fast-mixed-3", testNamespace, storageClassFast, "100Mi")
 			Expect(k8sClient.Create(ctx, fastPVC3)).To(Succeed(), "Should allow fast SSD PVC #3 within storage quota")
 
+			By("Waiting for controller to publish fast storage usage")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName,
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.storage", storageClassFast)),
+				resource.MustParse("2148Mi"),
+			)).To(Succeed())
+
 			By("Trying to create fast SSD PVC #4 that exceeds storage quota (should fail)")
 			fastPVC4 := createTestPVC("fast-mixed-4", testNamespace, storageClassFast, "1Gi")
 			err := k8sClient.Create(ctx, fastPVC4)
@@ -258,6 +286,13 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			slowPVC2 := createTestPVC("slow-mixed-2", testNamespace, storageClassSlow, "200Gi")
 			Expect(k8sClient.Create(ctx, slowPVC2)).To(Succeed(), "Should allow slow HDD PVC #2 within count quota")
 
+			By("Waiting for controller to publish slow PVC count usage")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName,
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClassSlow)),
+				resource.MustParse("2"),
+			)).To(Succeed())
+
 			By("Trying to create slow HDD PVC #3 that exceeds count quota (should fail)")
 			slowPVC3 := createTestPVC("slow-mixed-3", testNamespace, storageClassSlow, "1Mi")
 			err = k8sClient.Create(ctx, slowPVC3)
@@ -270,6 +305,13 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			By("Creating custom storage class PVC #1 (both quotas apply)")
 			customPVC1 := createTestPVC("custom-mixed-1", testNamespace, storageClassCustom, "1Gi")
 			Expect(k8sClient.Create(ctx, customPVC1)).To(Succeed(), "Should allow custom storage class PVC #1 within quotas")
+
+			By("Waiting for controller to publish custom PVC count usage")
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName,
+				corev1.ResourceName(fmt.Sprintf("%s.storageclass.storage.k8s.io/persistentvolumeclaims", storageClassCustom)),
+				resource.MustParse("1"),
+			)).To(Succeed())
 
 			By("Trying to create custom storage class PVC #2 that exceeds count quota (should fail)")
 			customPVC2 := createTestPVC("custom-mixed-2", testNamespace, storageClassCustom, "500Mi")

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -297,6 +297,36 @@ func GetCRQStatusUsage(crq *quotav1alpha1.ClusterResourceQuota) quotav1alpha1.Re
 	return crq.Status.Total.Used
 }
 
+// WaitForCRQResourceUsage polls until crq.Status.Total.Used[resourceName] equals expected.
+// Use this between "fill quota" operations and a subsequent "should be denied" assertion to
+// ensure the controller has aggregated the latest usage that the admission webhook will read.
+func WaitForCRQResourceUsage(
+	ctx context.Context,
+	k8sClient client.Client,
+	crqName string,
+	resourceName corev1.ResourceName,
+	expected resource.Quantity,
+) error {
+	const (
+		timeout  = 30 * time.Second
+		interval = 250 * time.Millisecond
+	)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return wait.PollUntilContextTimeout(ctxWithTimeout, interval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			crq := &quotav1alpha1.ClusterResourceQuota{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: crqName}, crq); err != nil {
+				return false, err
+			}
+			used, ok := crq.Status.Total.Used[resourceName]
+			if !ok {
+				return false, nil
+			}
+			return used.Cmp(expected) == 0, nil
+		})
+}
+
 // WaitForCRQStatus waits for the CRQ status to be updated with the expected namespaces.
 func WaitForCRQStatus(ctx context.Context, k8sClient client.Client, crqName string,
 	expectedNamespaces []string, timeout, interval time.Duration) error {


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

This pull request refactors the webhook admission controllers to simplify resource usage validation and improve metrics. The main changes remove direct Kubernetes client usage and calculator dependencies from the webhook handlers, instead validating against in-memory CRQ (ClusterResourceQuota) status. Additionally, new Prometheus metrics are introduced to track CRQ lookup outcomes and cold-start scenarios. The overall effect is a leaner, more testable codebase with improved observability.

**Metrics improvements:**
- Added two new Prometheus metrics: `WebhookCRQLookup` to track CRQ resolution outcomes during admission, and `WebhookStatusMissing` to count admissions allowed due to missing usage data in CRQ status. Both metrics are registered for collection. [[1]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R46-R63) [[2]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R107-R108)

**Webhook handler refactoring:**
- All webhook handlers (`PodWebhook`, `ServiceWebhook`, `PersistentVolumeClaimWebhook`, `ObjectCountWebhook`) no longer require a Kubernetes client or resource calculator. Instead, they validate resource requests directly against the in-memory CRQ status, reducing external dependencies and simplifying the constructor signatures. [[1]](diffhunk://#diff-6404509afd56daa425812290afd70394d934e45a776dcdb36087716a660c113aL167-R182) [[2]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L13) [[3]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L22-L30) [[4]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L39-R41) [[5]](diffhunk://#diff-c1388d67b88857518618b46530c018cd3edb8982453300c08aeab8f72c8e26d9L11-L31) [[6]](diffhunk://#diff-c1388d67b88857518618b46530c018cd3edb8982453300c08aeab8f72c8e26d9L40-L41) [[7]](diffhunk://#diff-c4e670c94b2ee0ede32cf16c113edd70b30a033751b46049afb3aad8b86a5146L10-L28) [[8]](diffhunk://#diff-c4e670c94b2ee0ede32cf16c113edd70b30a033751b46049afb3aad8b86a5146L37-L38) [[9]](diffhunk://#diff-d4ba2a893928419f7b42db6122672b5f9dee456bb505dfb5f3e0b1f78560cd86L6-L31) [[10]](diffhunk://#diff-d4ba2a893928419f7b42db6122672b5f9dee456bb505dfb5f3e0b1f78560cd86L40-L41)

**Resource validation logic updates:**
- Pod and PVC webhook validation now operate on the delta between new and old objects (for updates), and use a unified pattern for resource checks against CRQ status. This enables more accurate enforcement and prepares for future features, such as in-place resource resizing. [[1]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L60-R55) [[2]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L75-L160) [[3]](diffhunk://#diff-d4ba2a893928419f7b42db6122672b5f9dee456bb505dfb5f3e0b1f78560cd86L74-L162)

**Code cleanup and simplification:**
- Removed legacy usage calculation methods and related TODOs, further streamlining the webhook code and focusing on CRQ status validation. [[1]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L75-L160) [[2]](diffhunk://#diff-d4ba2a893928419f7b42db6122672b5f9dee456bb505dfb5f3e0b1f78560cd86L74-L162) [[3]](diffhunk://#diff-c4e670c94b2ee0ede32cf16c113edd70b30a033751b46049afb3aad8b86a5146L56-L58)

**Constructor and dependency injection changes:**
- Updated all webhook constructors to remove the Kubernetes client parameter, reflecting the new dependency model. [[1]](diffhunk://#diff-6404509afd56daa425812290afd70394d934e45a776dcdb36087716a660c113aL167-R182) [[2]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51L39-R41) [[3]](diffhunk://#diff-c1388d67b88857518618b46530c018cd3edb8982453300c08aeab8f72c8e26d9L40-L41) [[4]](diffhunk://#diff-c4e670c94b2ee0ede32cf16c113edd70b30a033751b46049afb3aad8b86a5146L37-L38) [[5]](diffhunk://#diff-d4ba2a893928419f7b42db6122672b5f9dee456bb505dfb5f3e0b1f78560cd86L40-L41)

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
  - Rewrote unit tests for all 4 webhooks + the shared handler. Coverage for `pkg/webhook/v1alpha1` rose from **89.7% → 93.8%**; total project coverage **49.7% → 49.8%**.
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed — no CRD / RBAC / chart impact.
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files`
  - [ ] `make test-e2e`

### Versioning & Release

- [ ] 📊 Bumped chart `version`
- [ ] 🏷️ Bumped `appVersion`
- [ ] 🔖 Tagged the release
