### PR TITLE
fix(renovate): add datasourceTemplate and depNameTemplate; bump quic-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.57.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3AdqE=
-github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,9 @@
       "fileMatch": ["^charts/pac-quota-controller/values.yaml$"],
       "matchStrings": [
         "repository:\\s*ghcr\\.io/powerhome/pac-quota-controller\\s*\\n\\s*tag:\\s*(?<currentValue>.+)"
-      ]
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/powerhome/pac-quota-controller"
     }
   ]
 }


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Fixes two configuration issues:

1. **Renovate regex manager** (closes #92): The `regexManagers` entry in `renovate.json` was missing the required `datasourceTemplate` and `depNameTemplate` fields, causing Renovate to reject the config and halt all PRs.

2. **`quic-go` security bump**: Upgrades `github.com/quic-go/quic-go` from `v0.57.0` → `v0.59.1` to resolve [dependabot alert #8](https://github.com/powerhome/pac-quota-controller/security/dependabot/8) — HTTP/3 QPACK Trailer Expansion Memory Exhaustion (moderate severity).

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior — no behavioral changes, config/dependency only
- [x] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed — N/A
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files`
  - [ ] `make test-e2e`

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **📝 Note:** Chart and app versioning are manual. See CONTRIBUTING.md for details on how to release.
> **🐙 Note:** For Helm chart installation, use GHCR as an OCI registry. See README for instructions.