### PR TITLE
chore: refactor e2e as code

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,11 +48,6 @@ jobs:
 
       - name: Verify kind installation
         run: kind version
-
-      - name: Create kind cluster
-        run: kind create cluster --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
-
-
       - name: Install kubectl
         run: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"

--- a/Makefile
+++ b/Makefile
@@ -83,36 +83,10 @@ install-tools: ## Install development tools
 .PHONY: deps
 deps: envtest golangci-lint mockery ## Install all development dependencies
 
-.PHONY: test-e2e-setup
-test-e2e-setup:
-	@echo "[test-e2e-setup] Building manager image..."
-	make docker-build IMG=$(IMG)
-	@echo "[test-e2e-setup] Ensuring Kind cluster exists..."
-	$(eval KIND_CLUSTER ?= pac-quota-controller-test-e2e)
-	@if ! kind get clusters | grep -q "^$(KIND_CLUSTER)$$" ; then \
-		kind create cluster --name $(KIND_CLUSTER) --image $(KIND_NODE_IMAGE); \
-	fi
-	@echo "[test-e2e-setup] Loading image to Kind..."
-	kind load docker-image $(IMG) --name $(KIND_CLUSTER)
-	make install-cert-manager
-	@echo "[test-e2e-setup] Deploying Helm chart with e2e configuration..."
-	make helm-deploy IMG=$(IMG)
-	@echo "[test-e2e-setup] Helm chart deployed and controller is available."
-	@echo "[test-e2e-setup] Waiting for controller to be ready..."
-	@$(KUBECTL) -n pac-quota-controller-system wait --for=condition=ready pod --timeout=60s -l control-plane=controller-manager
-	@echo "[test-e2e-setup] Controller is ready."
-
-.PHONY: test-e2e-cleanup
-# Clean up Kind cluster before/after e2e tests for a fully clean environment
-test-e2e-cleanup:
-	@echo "[test-e2e-cleanup] Deleting Kind cluster..."
-	$(KIND) delete cluster --name $(KIND_CLUSTER) || true
-
 .PHONY: test-e2e
-# Run e2e tests with setup/cleanup
-test-e2e: test-e2e-cleanup test-e2e-setup
-	KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
-	make test-e2e-cleanup
+# Run the e2e suite. The Go suite owns the cluster lifecycle; this is just an alias.
+test-e2e:
+	E2E_IMG=$(IMG) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
 lint: generate golangci-lint ## Run golangci-lint linter

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	testutils "github.com/powerhome/pac-quota-controller/test/utils"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,38 +22,55 @@ var (
 	k8sClient client.Client
 	clientSet *kubernetes.Clientset
 	ctx       context.Context
+	e2eConfig testutils.E2EConfig
 )
 
-// TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
-// temporary environment to validate project changes with the purposed to be used in CI jobs.
-// The default setup requires Kind, builds/loads the Manager Docker image locally, and installs
-// CertManager.
+// TestE2E runs the e2e suite. The suite owns the cluster lifecycle (tune via testutils.E2EConfig).
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting pac-quota-controller integration test suite\n")
 	RunSpecs(t, "e2e suite")
 }
 
-var _ = BeforeSuite(func() {
-	By("setting up logger to suppress controller-runtime warnings")
+// First func provisions the environment once; second runs on every process.
+var _ = SynchronizedBeforeSuite(func() []byte {
+	e2eConfig = testutils.LoadE2EConfig()
+	setupCtx := context.Background()
+
+	By("provisioning the e2e environment")
+	Expect(e2eConfig.Provision(setupCtx)).To(Succeed(), "Failed to provision e2e environment")
+
+	By("scrubbing leftovers from any previous run")
+	Expect(testutils.Scrub(setupCtx, newK8sClient())).To(Succeed(), "Failed to scrub cluster")
+	return nil
+}, func(_ []byte) {
+	e2eConfig = testutils.LoadE2EConfig()
+	ctx = context.Background()
+
 	log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	By("initializing Kubernetes client")
-	var err error
-	ctx = context.Background()
 	cfg, err := k8sconfig.GetConfig()
 	Expect(err).NotTo(HaveOccurred(), "Failed to get kubeconfig")
 
-	// Register ClusterResourceQuota CRD types with the global scheme.
-	// The global scheme already includes all built-in Kubernetes types.
-	err = v1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred(), "Failed to add ClusterResourceQuota types to scheme")
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred(), "Failed to create k8s client")
+	k8sClient = newK8sClient()
 	clientSet, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred(), "Failed to create Kubernetes clientset")
 })
 
-var _ = AfterSuite(func() {
+// Second func tears the environment down once, after all processes finish.
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	By("tearing down the e2e environment")
+	Expect(e2eConfig.Teardown(context.Background())).To(Succeed(), "Failed to tear down e2e environment")
 })
+
+// newK8sClient builds a controller-runtime client with the CRQ types registered.
+func newK8sClient() client.Client {
+	cfg, err := k8sconfig.GetConfig()
+	Expect(err).NotTo(HaveOccurred(), "Failed to get kubeconfig")
+
+	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed(), "Failed to add ClusterResourceQuota types to scheme")
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create k8s client")
+	return c
+}

--- a/test/utils/cluster.go
+++ b/test/utils/cluster.go
@@ -1,0 +1,290 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+)
+
+// Marks namespaces created by the e2e helpers so Scrub can find them.
+const (
+	E2ELabelKey   = "pac-quota-controller.powerapp.cloud/e2e"
+	E2ELabelValue = "true"
+
+	// Substring in test StorageClass names (e.g. "fast-ssd-e2e-<suffix>").
+	e2eStorageClassMarker = "-e2e-"
+)
+
+const (
+	defaultKindCluster   = "pac-quota-controller-test-e2e"
+	defaultNodeImage     = "kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
+	defaultImage         = "ghcr.io/powerhome/pac-quota-controller:latest"
+	defaultHelmRelease   = "pac-quota-controller"
+	defaultHelmNamespace = "pac-quota-controller-system"
+	defaultCertManagerNS = "cert-manager"
+	chartPath            = "./charts/pac-quota-controller"
+	controllerDeployment = "pac-quota-controller-manager"
+)
+
+// E2EConfig holds the e2e environment settings, read from the environment.
+type E2EConfig struct {
+	KindCluster   string
+	NodeImage     string
+	Image         string
+	HelmRelease   string
+	HelmNamespace string
+	CertManagerNS string
+
+	// Don't create or delete the cluster; fail if missing.
+	UseExistingCluster bool
+	// Reuse the image already loaded into the cluster.
+	SkipBuild bool
+	// Leave the cluster running after the suite.
+	SkipTeardown bool
+	// Assume the cluster/chart already exist; only build the client.
+	SkipSetup bool
+}
+
+// LoadE2EConfig reads the suite configuration from the environment.
+func LoadE2EConfig() E2EConfig {
+	return E2EConfig{
+		KindCluster: envOr("KIND_CLUSTER", defaultKindCluster),
+		NodeImage:   envOr("KIND_NODE_IMAGE", defaultNodeImage),
+		// IMG is the Makefile/CI convention; honor it as a fallback.
+		Image:              envOr("E2E_IMG", envOr("IMG", defaultImage)),
+		HelmRelease:        envOr("HELM_RELEASE_NAME", defaultHelmRelease),
+		HelmNamespace:      envOr("HELM_NAMESPACE", defaultHelmNamespace),
+		CertManagerNS:      envOr("CERT_MANAGER_NAMESPACE", defaultCertManagerNS),
+		UseExistingCluster: envBool("E2E_USE_EXISTING_CLUSTER"),
+		SkipBuild:          envBool("E2E_SKIP_BUILD"),
+		SkipTeardown:       envBool("E2E_SKIP_TEARDOWN"),
+		SkipSetup:          envBool("E2E_SKIP_SETUP"),
+	}
+}
+
+// Provision brings up the full environment: cluster, image, cert-manager, chart, readiness.
+func (c E2EConfig) Provision(ctx context.Context) error {
+	if c.SkipSetup {
+		return nil
+	}
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	if err := c.EnsureCluster(ctx); err != nil {
+		return err
+	}
+	if err := c.BuildAndLoadImage(ctx, root); err != nil {
+		return err
+	}
+	if err := c.InstallCertManager(ctx); err != nil {
+		return err
+	}
+	if err := c.DeployChart(ctx, root); err != nil {
+		return err
+	}
+	if err := c.WaitControllerReady(ctx); err != nil {
+		return err
+	}
+	return c.ExportKubeconfig(ctx)
+}
+
+// EnsureCluster creates the kind cluster only if it does not already exist.
+func (c E2EConfig) EnsureCluster(ctx context.Context) error {
+	out, err := runCmdOutput(ctx, "", "kind", "get", "clusters")
+	if err != nil {
+		return err
+	}
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.TrimSpace(line) == c.KindCluster {
+			return nil // already exists, reuse it
+		}
+	}
+	if c.UseExistingCluster {
+		return fmt.Errorf("E2E_USE_EXISTING_CLUSTER is set but kind cluster %q does not exist", c.KindCluster)
+	}
+	return runCmd(ctx, "", "kind", "create", "cluster", "--name", c.KindCluster, "--image", c.NodeImage)
+}
+
+// BuildAndLoadImage builds the manager image and loads it into the kind cluster.
+func (c E2EConfig) BuildAndLoadImage(ctx context.Context, root string) error {
+	if c.SkipBuild {
+		return nil
+	}
+	if err := runCmd(ctx, root, "docker", "build", "-t", c.Image, "."); err != nil {
+		return err
+	}
+	return runCmd(ctx, "", "kind", "load", "docker-image", c.Image, "--name", c.KindCluster)
+}
+
+// InstallCertManager installs cert-manager via Helm and waits for its webhook.
+func (c E2EConfig) InstallCertManager(ctx context.Context) error {
+	// Ignore error: fails if the repo is already added.
+	_ = runCmd(ctx, "", "helm", "repo", "add", "jetstack", "https://charts.jetstack.io")
+	if err := runCmd(ctx, "", "helm", "repo", "update"); err != nil {
+		return err
+	}
+	if err := runCmd(ctx, "", "helm", "upgrade", "--install", "cert-manager", "jetstack/cert-manager",
+		"--namespace", c.CertManagerNS, "--create-namespace",
+		"--set", "crds.enabled=true"); err != nil {
+		return err
+	}
+	return runCmd(ctx, "", "kubectl", "-n", c.CertManagerNS, "wait",
+		"--for=condition=Available", "deployment/cert-manager-webhook", "--timeout=2m")
+}
+
+// DeployChart installs/upgrades the controller Helm chart with the loaded image.
+func (c E2EConfig) DeployChart(ctx context.Context, root string) error {
+	repo, tag := splitImage(c.Image)
+	return runCmd(ctx, root, "helm", "upgrade", "--install", c.HelmRelease, chartPath,
+		"--namespace", c.HelmNamespace, "--create-namespace",
+		"--set", "controllerManager.container.image.repository="+repo,
+		"--set", "controllerManager.container.image.tag="+tag,
+		"--set", "controllerManager.container.image.pullPolicy=Never",
+		"--wait", "--timeout", "10m0s")
+}
+
+// WaitControllerReady blocks until the controller has rolled out and its pod is ready.
+func (c E2EConfig) WaitControllerReady(ctx context.Context) error {
+	if err := runCmd(ctx, "", "kubectl", "-n", c.HelmNamespace, "rollout", "status",
+		"deployment/"+controllerDeployment, "--timeout=2m"); err != nil {
+		return err
+	}
+	return runCmd(ctx, "", "kubectl", "-n", c.HelmNamespace, "wait",
+		"--for=condition=ready", "pod", "--timeout=60s", "-l", "control-plane=controller-manager")
+}
+
+// ExportKubeconfig points the current kubeconfig context at the kind cluster.
+func (c E2EConfig) ExportKubeconfig(ctx context.Context) error {
+	if c.SkipSetup {
+		return nil
+	}
+	return runCmd(ctx, "", "kind", "export", "kubeconfig", "--name", c.KindCluster)
+}
+
+// Teardown deletes the kind cluster unless told to keep or reuse it.
+func (c E2EConfig) Teardown(ctx context.Context) error {
+	if c.SkipSetup || c.SkipTeardown || c.UseExistingCluster {
+		return nil
+	}
+	return runCmd(ctx, "", "kind", "delete", "cluster", "--name", c.KindCluster)
+}
+
+// Scrub deletes leftovers from a previous run: all CRQs (cluster-scoped, the main
+// cross-run hazard) plus e2e-labeled namespaces and test StorageClasses.
+func Scrub(ctx context.Context, k8sClient client.Client) error {
+	crqList := &quotav1alpha1.ClusterResourceQuotaList{}
+	if err := k8sClient.List(ctx, crqList); err != nil {
+		return fmt.Errorf("scrub: list CRQs: %w", err)
+	}
+	for i := range crqList.Items {
+		if err := k8sClient.Delete(ctx, &crqList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("scrub: delete CRQ %s: %w", crqList.Items[i].Name, err)
+		}
+	}
+
+	nsList := &corev1.NamespaceList{}
+	if err := k8sClient.List(ctx, nsList, client.MatchingLabels{E2ELabelKey: E2ELabelValue}); err != nil {
+		return fmt.Errorf("scrub: list namespaces: %w", err)
+	}
+	for i := range nsList.Items {
+		if err := k8sClient.Delete(ctx, &nsList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("scrub: delete namespace %s: %w", nsList.Items[i].Name, err)
+		}
+	}
+
+	scList := &storagev1.StorageClassList{}
+	if err := k8sClient.List(ctx, scList); err != nil {
+		return fmt.Errorf("scrub: list storageclasses: %w", err)
+	}
+	for i := range scList.Items {
+		if !strings.Contains(scList.Items[i].Name, e2eStorageClassMarker) {
+			continue
+		}
+		if err := k8sClient.Delete(ctx, &scList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("scrub: delete storageclass %s: %w", scList.Items[i].Name, err)
+		}
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envBool(key string) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// splitImage splits "repo:tag" on the last colon.
+func splitImage(image string) (repo, tag string) {
+	if i := strings.LastIndex(image, ":"); i >= 0 && !strings.Contains(image[i:], "/") {
+		return image[:i], image[i+1:]
+	}
+	return image, "latest"
+}
+
+// repoRoot walks up from this file to the dir containing go.mod.
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("repoRoot: cannot determine caller path")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("repoRoot: go.mod not found above %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+func runCmd(ctx context.Context, dir, name string, args ...string) error {
+	_, _ = fmt.Fprintf(os.Stdout, "[e2e] $ %s %s\n", name, strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command failed: %s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func runCmdOutput(ctx context.Context, dir, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("command failed: %s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return out.String(), nil
+}

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -120,6 +120,11 @@ func DescribePod(ctx context.Context, k8sClient client.Client, namespace, podNam
 // CreateNamespace creates a namespace with the specified name and labels.
 func CreateNamespace(ctx context.Context, k8sClient client.Client, namespace string,
 	nsLabels map[string]string) (*corev1.Namespace, error) {
+	// Tag test namespaces so Scrub can clean them up.
+	if nsLabels == nil {
+		nsLabels = map[string]string{}
+	}
+	nsLabels[E2ELabelKey] = E2ELabelValue
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

<!--
Provide a detailed description of your changes:
- What problem does this solve?
- How did you solve it?
- What are the key changes?
- Why did you choose this approach?
-->
This pull request overhauls the end-to-end (e2e) test environment management for the project. The main improvement is moving the cluster lifecycle management (setup, teardown, image loading, etc.) from shell scripts and Makefile targets into Go code, specifically into the e2e test suite itself. This makes the tests more robust, portable, and easier to configure, especially for CI environments. The Makefile and GitHub Actions workflow are simplified, and a new `test/utils/cluster.go` helper is introduced to encapsulate all environment provisioning logic.

**End-to-end environment management refactor:**

* Introduced a new `testutils.E2EConfig` struct and supporting helpers in `test/utils/cluster.go` to manage cluster setup, image building/loading, Helm deployment, cert-manager installation, and cleanup directly from Go, based on environment variables. This allows the Go test suite to fully own the lifecycle of the test environment, supporting flexible local and CI workflows.
* Updated the e2e test suite (`test/e2e/e2e_suite_test.go`) to use the new `E2EConfig` for provisioning and tearing down the environment, including using `SynchronizedBeforeSuite` and `SynchronizedAfterSuite` for parallel test safety. Also added a `Scrub` helper to clean up test artifacts between runs. [[1]](diffhunk://#diff-93b46b0715181c9cf397eed60862261b7839ff721599fcc393a393b9edea610bR12) [[2]](diffhunk://#diff-93b46b0715181c9cf397eed60862261b7839ff721599fcc393a393b9edea610bR25-R76)
* Added automatic labeling of test-created namespaces so they can be reliably cleaned up by the `Scrub` function, reducing cross-test contamination.

**Build and test workflow simplification:**

* Removed complex e2e setup/cleanup logic from the `Makefile` and replaced it with a simple `test-e2e` target that delegates all environment management to the Go suite, making the Makefile and CI integration much simpler.
* Removed redundant kind cluster creation from the GitHub Actions workflow, as this is now handled by the Go test suite.

## 📚 Documentation

<!--
Describe documentation changes:
- Updated README
- Added new docs
- Updated API documentation

-->

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [X] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [ ] 🔧 Ran pre-commit hooks to validate changes:
  - [ ] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **📝 Note:** Chart and app versioning are manual. See CONTRIBUTING.md for details on how to release.
> **🐙 Note:** For Helm chart installation, use GHCR as an OCI registry. See README for instructions.
