### PR TITLE
test(kubernetes): cover pod/storage/namespace aggregation funcs

### DIFF
--- a/pkg/kubernetes/namespace/namespace_validation_test.go
+++ b/pkg/kubernetes/namespace/namespace_validation_test.go
@@ -1,0 +1,185 @@
+package namespace
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/quota"
+)
+
+// teamA is a shared (read-only) label set used across the conflict tests.
+var teamA = map[string]string{"team": "a"}
+
+func crqSelecting(name string, matchLabels map[string]string) *quotav1alpha1.ClusterResourceQuota {
+	return &quotav1alpha1.ClusterResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: matchLabels},
+		},
+	}
+}
+
+func namespaceWithLabels(name string, lbls map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: lbls}}
+}
+
+func validationScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	Expect(corev1.AddToScheme(s)).To(Succeed())
+	Expect(quotav1alpha1.AddToScheme(s)).To(Succeed())
+	return s
+}
+
+var _ = Describe("Namespace CRQ conflict validation", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	// newCRQClient builds a quota.CRQClient backed by a fake runtime client holding crqs.
+	newCRQClient := func(crqs ...*quotav1alpha1.ClusterResourceQuota) *quota.CRQClient {
+		builder := crfake.NewClientBuilder().WithScheme(validationScheme())
+		for _, crq := range crqs {
+			builder = builder.WithObjects(crq)
+		}
+		return quota.NewCRQClient(builder.Build(), zap.NewNop())
+	}
+
+	Describe("ValidateNamespaceAgainstCRQs (validator method)", func() {
+		It("returns nil when no CRQ selects the namespace", func() {
+			validator := NewNamespaceValidator(k8sfake.NewSimpleClientset(), newCRQClient(crqSelecting("crq-a", teamA)))
+			err := validator.ValidateNamespaceAgainstCRQs(ctx, namespaceWithLabels("ns1", map[string]string{"team": "b"}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil when exactly one CRQ selects the namespace", func() {
+			validator := NewNamespaceValidator(k8sfake.NewSimpleClientset(), newCRQClient(crqSelecting("crq-a", teamA)))
+			err := validator.ValidateNamespaceAgainstCRQs(ctx, namespaceWithLabels("ns1", teamA))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when multiple CRQs select the namespace", func() {
+			validator := NewNamespaceValidator(
+				k8sfake.NewSimpleClientset(),
+				newCRQClient(
+					crqSelecting("crq-a", map[string]string{"team": "a"}),
+					crqSelecting("crq-b", map[string]string{"team": "a"}),
+				),
+			)
+			err := validator.ValidateNamespaceAgainstCRQs(ctx, namespaceWithLabels("ns1", map[string]string{"team": "a"}))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("multiple ClusterResourceQuotas select namespace"))
+		})
+	})
+
+	Describe("ValidateNamespaceAgainstCRQs (free function)", func() {
+		It("returns nil when the CRQ client is nil", func() {
+			ns := namespaceWithLabels("ns1", teamA)
+			err := ValidateNamespaceAgainstCRQs(ctx, k8sfake.NewSimpleClientset(), nil, ns)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when multiple CRQs select the namespace", func() {
+			crqClient := newCRQClient(crqSelecting("crq-a", teamA), crqSelecting("crq-b", teamA))
+			ns := namespaceWithLabels("ns1", teamA)
+			err := ValidateNamespaceAgainstCRQs(ctx, k8sfake.NewSimpleClientset(), crqClient, ns)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("multiple ClusterResourceQuotas select namespace"))
+		})
+	})
+
+	Describe("namespaceMatchesCRQ", func() {
+		It("returns true when the namespace matches the CRQ selector", func() {
+			validator := NewNamespaceValidator(k8sfake.NewSimpleClientset(), newCRQClient())
+			matches, err := validator.namespaceMatchesCRQ(
+				namespaceWithLabels("ns1", map[string]string{"team": "a"}),
+				crqSelecting("crq-a", map[string]string{"team": "a"}),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matches).To(BeTrue())
+		})
+
+		It("returns false when the namespace does not match", func() {
+			validator := NewNamespaceValidator(k8sfake.NewSimpleClientset(), newCRQClient())
+			matches, err := validator.namespaceMatchesCRQ(
+				namespaceWithLabels("ns1", map[string]string{"team": "b"}),
+				crqSelecting("crq-a", map[string]string{"team": "a"}),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matches).To(BeFalse())
+		})
+
+		It("returns false when the CRQ client is nil", func() {
+			validator := NewNamespaceValidator(k8sfake.NewSimpleClientset(), nil)
+			matches, err := validator.namespaceMatchesCRQ(
+				namespaceWithLabels("ns1", map[string]string{"team": "a"}),
+				crqSelecting("crq-a", map[string]string{"team": "a"}),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matches).To(BeFalse())
+		})
+	})
+
+	Describe("findConflictingCRQsForNamespaces", func() {
+		It("reports namespaces already owned by another CRQ, excluding the current one", func() {
+			ns1 := namespaceWithLabels("ns1", map[string]string{"team": "a"})
+			validator := NewNamespaceValidator(
+				k8sfake.NewSimpleClientset(ns1),
+				newCRQClient(
+					crqSelecting("crq-a", map[string]string{"team": "a"}),
+					crqSelecting("crq-b", map[string]string{"team": "a"}),
+				),
+			)
+			conflicts, err := validator.findConflictingCRQsForNamespaces(ctx, []string{"ns1"}, "crq-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conflicts).To(HaveKeyWithValue("ns1", ConsistOf("crq-b")))
+		})
+
+		It("returns no conflicts when the namespace does not exist", func() {
+			validator := NewNamespaceValidator(
+				k8sfake.NewSimpleClientset(),
+				newCRQClient(crqSelecting("crq-b", map[string]string{"team": "a"})),
+			)
+			conflicts, err := validator.findConflictingCRQsForNamespaces(ctx, []string{"missing"}, "crq-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conflicts).To(BeEmpty())
+		})
+	})
+
+	Describe("ValidateCRQNamespaceConflicts conflict path", func() {
+		It("returns an ownership-conflict error when an intended namespace is owned by another CRQ", func() {
+			ns1 := namespaceWithLabels("ns1", map[string]string{"team": "a"})
+			validator := NewNamespaceValidator(
+				k8sfake.NewSimpleClientset(ns1),
+				newCRQClient(crqSelecting("crq-b", map[string]string{"team": "a"})),
+			)
+			err := validator.ValidateCRQNamespaceConflicts(ctx, crqSelecting("crq-a", map[string]string{"team": "a"}))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("namespace ownership conflict"))
+		})
+	})
+
+	Describe("GetSelectedNamespaces with matching namespaces", func() {
+		It("returns the sorted set of namespaces matching the CRQ selector", func() {
+			client := k8sfake.NewSimpleClientset(
+				namespaceWithLabels("ns-b", map[string]string{"team": "a"}),
+				namespaceWithLabels("ns-a", map[string]string{"team": "a"}),
+				namespaceWithLabels("ns-c", map[string]string{"team": "other"}),
+			)
+			selected, err := GetSelectedNamespaces(ctx, client, crqSelecting("crq-a", map[string]string{"team": "a"}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(selected).To(Equal([]string{"ns-a", "ns-b"}))
+		})
+	})
+})

--- a/pkg/kubernetes/pod/pod_aggregation_test.go
+++ b/pkg/kubernetes/pod/pod_aggregation_test.go
@@ -1,0 +1,131 @@
+package pod
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
+)
+
+// podWithCPU builds a single-container pod requesting the given CPU in the given phase.
+func podWithCPU(name, cpu string, phase corev1.PodPhase) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "c",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(cpu)},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+var _ = Describe("CalculateUsageFromPods", func() {
+	Describe("pod count", func() {
+		It("counts only non-terminal pods", func() {
+			pods := []corev1.Pod{
+				podWithCPU("running", "100m", corev1.PodRunning),
+				podWithCPU("pending", "100m", corev1.PodPending),
+				podWithCPU("succeeded", "100m", corev1.PodSucceeded),
+				podWithCPU("failed", "100m", corev1.PodFailed),
+			}
+			result := CalculateUsageFromPods(pods, usage.ResourcePods)
+			Expect(result.Value()).To(Equal(int64(2)))
+		})
+
+		It("returns zero for an empty list", func() {
+			empty := CalculateUsageFromPods([]corev1.Pod{}, usage.ResourcePods)
+			Expect(empty.Value()).To(Equal(int64(0)))
+		})
+
+		It("returns zero for a nil list", func() {
+			nilList := CalculateUsageFromPods(nil, usage.ResourcePods)
+			Expect(nilList.Value()).To(Equal(int64(0)))
+		})
+	})
+
+	Describe("resource sum", func() {
+		It("sums CPU across non-terminal pods and excludes terminal ones", func() {
+			pods := []corev1.Pod{
+				podWithCPU("running", "100m", corev1.PodRunning),
+				podWithCPU("pending", "250m", corev1.PodPending),
+				podWithCPU("succeeded", "500m", corev1.PodSucceeded),
+				podWithCPU("failed", "999m", corev1.PodFailed),
+			}
+			result := CalculateUsageFromPods(pods, corev1.ResourceRequestsCPU)
+			Expect(result.Equal(resource.MustParse("350m"))).To(BeTrue())
+		})
+
+		It("returns zero for an empty list", func() {
+			empty := CalculateUsageFromPods([]corev1.Pod{}, corev1.ResourceRequestsCPU)
+			Expect(empty.IsZero()).To(BeTrue())
+		})
+
+		It("returns zero for a nil list", func() {
+			nilList := CalculateUsageFromPods(nil, corev1.ResourceRequestsCPU)
+			Expect(nilList.IsZero()).To(BeTrue())
+		})
+
+		It("returns zero when every pod is terminal", func() {
+			pods := []corev1.Pod{
+				podWithCPU("succeeded", "500m", corev1.PodSucceeded),
+				podWithCPU("failed", "500m", corev1.PodFailed),
+			}
+			allTerminal := CalculateUsageFromPods(pods, corev1.ResourceRequestsCPU)
+			Expect(allTerminal.IsZero()).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("CalculatePodUsage extra branches", func() {
+	It("returns an empty quantity for a nil pod", func() {
+		nilUsage := CalculatePodUsage(nil, corev1.ResourceRequestsCPU)
+		Expect(nilUsage.IsZero()).To(BeTrue())
+	})
+
+	It("uses the app-container sum when it exceeds the max init container", func() {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name: "init",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("150m")},
+					},
+				}},
+				Containers: []corev1.Container{
+					{Name: "a", Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+					}},
+					{Name: "b", Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")},
+					}},
+				},
+			},
+		}
+		// max(sum(app)=500m, maxInit=150m) = 500m
+		Expect(CalculatePodUsage(pod, corev1.ResourceRequestsCPU).Equal(resource.MustParse("500m"))).To(BeTrue())
+	})
+
+	It("adds overhead keyed by the exact resource name", func() {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Overhead: corev1.ResourceList{corev1.ResourceRequestsCPU: resource.MustParse("50m")},
+				Containers: []corev1.Container{{
+					Name: "c",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+					},
+				}},
+			},
+		}
+		// overhead(50m, exact key) + app(100m) = 150m
+		Expect(CalculatePodUsage(pod, corev1.ResourceRequestsCPU).Equal(resource.MustParse("150m"))).To(BeTrue())
+	})
+})

--- a/pkg/kubernetes/storage/storage_aggregation_test.go
+++ b/pkg/kubernetes/storage/storage_aggregation_test.go
@@ -1,0 +1,143 @@
+package storage
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// pvc builds a PVC with the given storage request and spec storage class.
+func pvc(name, storageReq, class string) corev1.PersistentVolumeClaim {
+	p := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(storageReq)},
+			},
+		},
+	}
+	if class != "" {
+		p.Spec.StorageClassName = &class
+	}
+	return p
+}
+
+var _ = Describe("Storage list aggregation", func() {
+	Describe("CalculateStorageUsageFromPVCs", func() {
+		It("sums storage requests across PVCs", func() {
+			pvcs := []corev1.PersistentVolumeClaim{
+				pvc("a", "10Gi", ""),
+				pvc("b", "5Gi", ""),
+			}
+			total := CalculateStorageUsageFromPVCs(pvcs, corev1.ResourceRequestsStorage)
+			Expect(total.Equal(resource.MustParse("15Gi"))).To(BeTrue())
+		})
+
+		It("returns zero for a non-storage resource name", func() {
+			pvcs := []corev1.PersistentVolumeClaim{pvc("a", "10Gi", "")}
+			total := CalculateStorageUsageFromPVCs(pvcs, corev1.ResourceRequestsMemory)
+			Expect(total.IsZero()).To(BeTrue())
+		})
+
+		It("returns zero for an empty list", func() {
+			total := CalculateStorageUsageFromPVCs(nil, corev1.ResourceRequestsStorage)
+			Expect(total.IsZero()).To(BeTrue())
+		})
+	})
+
+	Describe("CalculatePVCCountUsageFromPVCs", func() {
+		It("counts PVCs", func() {
+			pvcs := []corev1.PersistentVolumeClaim{pvc("a", "1Gi", ""), pvc("b", "1Gi", "")}
+			count := CalculatePVCCountUsageFromPVCs(pvcs)
+			Expect(count.Value()).To(Equal(int64(2)))
+		})
+
+		It("returns zero for an empty list", func() {
+			count := CalculatePVCCountUsageFromPVCs(nil)
+			Expect(count.Value()).To(Equal(int64(0)))
+		})
+	})
+
+	Describe("CalculateStorageClassUsageFromPVCs", func() {
+		It("sums only PVCs matching the storage class", func() {
+			pvcs := []corev1.PersistentVolumeClaim{
+				pvc("fast-a", "10Gi", "fast"),
+				pvc("fast-b", "20Gi", "fast"),
+				pvc("slow-a", "100Gi", "slow"),
+			}
+			total := CalculateStorageClassUsageFromPVCs(pvcs, "fast")
+			Expect(total.Equal(resource.MustParse("30Gi"))).To(BeTrue())
+		})
+
+		It("returns zero when no PVC matches", func() {
+			pvcs := []corev1.PersistentVolumeClaim{pvc("slow-a", "100Gi", "slow")}
+			total := CalculateStorageClassUsageFromPVCs(pvcs, "fast")
+			Expect(total.IsZero()).To(BeTrue())
+		})
+	})
+
+	Describe("CalculateStorageClassCountFromPVCs", func() {
+		It("counts only PVCs matching the storage class", func() {
+			pvcs := []corev1.PersistentVolumeClaim{
+				pvc("fast-a", "10Gi", "fast"),
+				pvc("fast-b", "20Gi", "fast"),
+				pvc("slow-a", "100Gi", "slow"),
+			}
+			Expect(CalculateStorageClassCountFromPVCs(pvcs, "fast")).To(Equal(int64(2)))
+		})
+
+		It("returns zero when no PVC matches", func() {
+			pvcs := []corev1.PersistentVolumeClaim{pvc("slow-a", "100Gi", "slow")}
+			Expect(CalculateStorageClassCountFromPVCs(pvcs, "fast")).To(Equal(int64(0)))
+		})
+	})
+})
+
+var _ = Describe("PVCStorageClass", func() {
+	It("returns the spec storage class name when set", func() {
+		p := pvc("a", "1Gi", "fast")
+		Expect(PVCStorageClass(&p)).To(Equal("fast"))
+	})
+
+	It("falls back to the legacy annotation when spec is unset", func() {
+		p := corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"volume.beta.kubernetes.io/storage-class": "legacy"},
+			},
+		}
+		Expect(PVCStorageClass(&p)).To(Equal("legacy"))
+	})
+
+	It("returns empty when neither spec nor annotation is set", func() {
+		p := corev1.PersistentVolumeClaim{}
+		Expect(PVCStorageClass(&p)).To(Equal(""))
+	})
+
+	It("returns empty for a nil PVC", func() {
+		Expect(PVCStorageClass(nil)).To(Equal(""))
+	})
+})
+
+var _ = Describe("PVCMatchesStorageClass legacy annotation", func() {
+	It("matches via the legacy annotation when spec is unset", func() {
+		p := corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"volume.beta.kubernetes.io/storage-class": "legacy"},
+			},
+		}
+		Expect(PVCMatchesStorageClass(&p, "legacy")).To(BeTrue())
+		Expect(PVCMatchesStorageClass(&p, "other")).To(BeFalse())
+	})
+
+	It("does not match when spec and annotation are both unset", func() {
+		p := corev1.PersistentVolumeClaim{}
+		Expect(PVCMatchesStorageClass(&p, "")).To(BeFalse())
+	})
+
+	It("returns false for a nil PVC", func() {
+		Expect(PVCMatchesStorageClass(nil, "fast")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## What

Adds unit tests for the resource-usage aggregation functions that previously had **zero direct coverage**, before they are modified by upcoming work (e.g. quota scopes).

## Coverage gains

| Package | Before | After |
|---------|--------|-------|
| `pod` | 79.2% | 98.6% |
| `storage` | 25.6% | 100% |
| `namespace` | 47.4% | 88.3% |

## Details

- **pod** — `CalculateUsageFromPods` (list sum, pod count, terminal-pod exclusion, empty/nil) and the previously-untested `CalculatePodUsage` branches (nil pod, app-sum > init-max, exact-key overhead).
- **storage** — `CalculateStorageUsageFromPVCs`, `CalculatePVCCountUsageFromPVCs`, `CalculateStorageClass{Usage,Count}FromPVCs`, plus `PVCStorageClass` / `PVCMatchesStorageClass` including the legacy-annotation fallback and per-storage-class filtering.
- **namespace** — `ValidateNamespaceAgainstCRQs` (method + free func), `namespaceMatchesCRQ`, `findConflictingCRQsForNamespaces`, the `ValidateCRQNamespaceConflicts` conflict path, and `GetSelectedNamespaces` with actually-matching namespaces.

No production code changes — tests only.
