### PR TITLE
test(e2e): multi-namespace aggregation, fail-open, and event coverage

### DIFF
--- a/pkg/events/cleanup.go
+++ b/pkg/events/cleanup.go
@@ -28,6 +28,13 @@ func eventTime(e *eventsv1.Event) time.Time {
 	return e.DeprecatedFirstTimestamp.Time
 }
 
+const (
+	// crqEventKind is the Regarding kind on every event the controller records.
+	crqEventKind = "ClusterResourceQuota"
+	// eventSource labels the cleanup metric; only the controller emits events.
+	eventSource = "controller"
+)
+
 // CleanupConfig holds configuration for event cleanup
 type CleanupConfig struct {
 	// MaxAge is the maximum age for events before cleanup
@@ -104,32 +111,20 @@ func (m *EventCleanupManager) Start(ctx context.Context) {
 
 // cleanup performs the actual event cleanup
 func (m *EventCleanupManager) cleanup(ctx context.Context) error {
-	controllerEvents, err := m.getPACEvents(ctx, "controller")
+	allEvents, err := m.getPACEvents(ctx)
 	if err != nil {
 		return err
 	}
-
-	webhookEvents, err := m.getPACEvents(ctx, "webhook")
-	if err != nil {
-		return err
-	}
-
-	allEvents := append(controllerEvents.Items, webhookEvents.Items...)
 
 	if len(allEvents) == 0 {
 		m.logger.Debug("No PAC quota events found for cleanup")
 		return nil
 	}
 
-	// Group events by CRQ
+	// Group events by the CRQ they were recorded against.
 	eventsByCRQ := make(map[string][]eventsv1.Event)
 	for _, event := range allEvents {
-		crqName := event.Labels[LabelCRQName]
-		if crqName == "" {
-			// Skip events without CRQ label (shouldn't happen with our events)
-			continue
-		}
-		eventsByCRQ[crqName] = append(eventsByCRQ[crqName], event)
+		eventsByCRQ[event.Regarding.Name] = append(eventsByCRQ[event.Regarding.Name], event)
 	}
 
 	var deletedCount int
@@ -148,19 +143,20 @@ func (m *EventCleanupManager) cleanup(ctx context.Context) error {
 	return nil
 }
 
-// getPACEvents retrieves PAC quota events emitted from the given source
-// ("controller" or "webhook").
-func (m *EventCleanupManager) getPACEvents(ctx context.Context, source string) (*eventsv1.EventList, error) {
-	events := &eventsv1.EventList{}
-	listOpts := []client.ListOption{
-		client.MatchingLabels{LabelEventSource: source},
-	}
-
-	if err := m.client.List(ctx, events, listOpts...); err != nil {
+// getPACEvents lists every event the controller recorded against a CRQ.
+func (m *EventCleanupManager) getPACEvents(ctx context.Context) ([]eventsv1.Event, error) {
+	list := &eventsv1.EventList{}
+	if err := m.client.List(ctx, list); err != nil {
 		return nil, err
 	}
 
-	return events, nil
+	pac := make([]eventsv1.Event, 0, len(list.Items))
+	for i := range list.Items {
+		if list.Items[i].Regarding.Kind == crqEventKind {
+			pac = append(pac, list.Items[i])
+		}
+	}
+	return pac, nil
 }
 
 // cleanupEventsForCRQ cleans up events for a specific CRQ
@@ -201,11 +197,7 @@ func (m *EventCleanupManager) cleanupEventsForCRQ(ctx context.Context, crqName s
 				zap.String("reason", event.Reason))
 		} else {
 			deletedCount++
-			source := event.Labels[LabelEventSource]
-			if source == "" {
-				source = "unknown"
-			}
-			metrics.EventsCleanedTotal.WithLabelValues(source).Inc()
+			metrics.EventsCleanedTotal.WithLabelValues(eventSource).Inc()
 			m.logger.Debug("Deleted old event",
 				zap.String("event", event.Name),
 				zap.String("crq_name", crqName),
@@ -226,31 +218,18 @@ func (m *EventCleanupManager) cleanupEventsForCRQ(ctx context.Context, crqName s
 
 // GetCleanupStats returns statistics about the cleanup operation (for testing/monitoring)
 func (m *EventCleanupManager) GetCleanupStats(ctx context.Context) (map[string]int, error) {
-	stats := make(map[string]int)
-
-	controllerEvents, err := m.getPACEvents(ctx, "controller")
+	allEvents, err := m.getPACEvents(ctx)
 	if err != nil {
 		return nil, err
 	}
-	stats["controller_events"] = len(controllerEvents.Items)
 
-	webhookEvents, err := m.getPACEvents(ctx, "webhook")
-	if err != nil {
-		return nil, err
-	}
-	stats["webhook_events"] = len(webhookEvents.Items)
-
-	// Count by CRQ
-	allEvents := append(controllerEvents.Items, webhookEvents.Items...)
 	crqCounts := make(map[string]int)
 	for _, event := range allEvents {
-		crqName := event.Labels[LabelCRQName]
-		if crqName != "" {
-			crqCounts[crqName]++
-		}
+		crqCounts[event.Regarding.Name]++
 	}
-	stats["total_events"] = len(allEvents)
-	stats["crqs_with_events"] = len(crqCounts)
 
-	return stats, nil
+	return map[string]int{
+		"total_events":     len(allEvents),
+		"crqs_with_events": len(crqCounts),
+	}, nil
 }

--- a/pkg/events/cleanup_test.go
+++ b/pkg/events/cleanup_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,20 +25,16 @@ func newCleanupTestScheme() *runtime.Scheme {
 	return s
 }
 
-func makePACEvent(name, source, crq string, at time.Time) *eventsv1.Event {
+// makePACEvent builds an event as the controller records it: regarding the CRQ,
+// with no PAC labels (the events.k8s.io recorder does not set any).
+func makePACEvent(name, crq string, at time.Time) *eventsv1.Event {
 	return &eventsv1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "kube-system",
-			Labels: map[string]string{
-				LabelEventSource: source,
-				LabelCRQName:     crq,
-			},
-		},
-		EventTime: metav1.MicroTime{Time: at},
-		Reason:    "QuotaExceeded",
-		Type:      "Warning",
-		Note:      "test event",
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Regarding:  corev1.ObjectReference{Kind: crqEventKind, Name: crq},
+		EventTime:  metav1.MicroTime{Time: at},
+		Reason:     "QuotaExceeded",
+		Type:       "Warning",
+		Note:       "test event",
 	}
 }
 
@@ -52,15 +49,26 @@ var _ = Describe("EventCleanupManager.cleanup", func() {
 		logger = zap.NewNop()
 	})
 
-	It("deletes expired events from both controller and webhook sources", func() {
-		old := time.Now().Add(-48 * time.Hour) // older than MaxAge
+	assertGone := func(fc client.Client, name string) {
+		err := fc.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &eventsv1.Event{})
+		Expect(client.IgnoreNotFound(err)).To(Succeed())
+		Expect(err).To(HaveOccurred(), "expected %s to be deleted", name)
+	}
+	assertExists := func(fc client.Client, name string) {
+		Expect(fc.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &eventsv1.Event{})).
+			To(Succeed(), "expected %s to be kept", name)
+	}
 
-		ctrlEvent := makePACEvent("evt-ctrl", "controller", "quota-a", old)
-		webhookEvent := makePACEvent("evt-webhook", "webhook", "quota-a", old)
+	It("deletes expired CRQ events and counts them, keeping fresh ones", func() {
+		old := time.Now().Add(-48 * time.Hour) // older than MaxAge
 
 		fc := clientfake.NewClientBuilder().
 			WithScheme(newCleanupTestScheme()).
-			WithObjects(ctrlEvent, webhookEvent).
+			WithObjects(
+				makePACEvent("evt-old-1", "quota-a", old),
+				makePACEvent("evt-old-2", "quota-a", old),
+				makePACEvent("evt-fresh", "quota-a", time.Now()),
+			).
 			Build()
 
 		mgr := NewEventCleanupManager(fc, CleanupConfig{
@@ -70,22 +78,65 @@ var _ = Describe("EventCleanupManager.cleanup", func() {
 			Enabled:         true,
 		}, logger)
 
-		preCtrl := promtestutil.ToFloat64(metrics.EventsCleanedTotal.WithLabelValues("controller"))
-		preWebhook := promtestutil.ToFloat64(metrics.EventsCleanedTotal.WithLabelValues("webhook"))
+		pre := promtestutil.ToFloat64(metrics.EventsCleanedTotal.WithLabelValues(eventSource))
+		Expect(mgr.cleanup(ctx)).To(Succeed())
+
+		assertGone(fc, "evt-old-1")
+		assertGone(fc, "evt-old-2")
+		assertExists(fc, "evt-fresh")
+		Expect(promtestutil.ToFloat64(metrics.EventsCleanedTotal.WithLabelValues(eventSource)) - pre).
+			To(Equal(float64(2)))
+	})
+
+	It("trims to MaxEventsPerCRQ, keeping the newest events", func() {
+		now := time.Now()
+
+		fc := clientfake.NewClientBuilder().
+			WithScheme(newCleanupTestScheme()).
+			WithObjects(
+				makePACEvent("evt-oldest", "quota-b", now.Add(-3*time.Hour)),
+				makePACEvent("evt-middle", "quota-b", now.Add(-2*time.Hour)),
+				makePACEvent("evt-newest", "quota-b", now.Add(-1*time.Hour)),
+			).
+			Build()
+
+		mgr := NewEventCleanupManager(fc, CleanupConfig{
+			MaxAge:          24 * time.Hour, // none are expired by age
+			MaxEventsPerCRQ: 2,
+			CleanupInterval: time.Hour,
+			Enabled:         true,
+		}, logger)
 
 		Expect(mgr.cleanup(ctx)).To(Succeed())
 
-		assertGone := func(name string) {
-			err := fc.Get(ctx, types.NamespacedName{Name: name, Namespace: "kube-system"}, &eventsv1.Event{})
-			Expect(client.IgnoreNotFound(err)).To(Succeed())
-			Expect(err).To(HaveOccurred(), "expected %s to be deleted", name)
-		}
-		assertGone("evt-ctrl")
-		assertGone("evt-webhook")
+		assertGone(fc, "evt-oldest")
+		assertExists(fc, "evt-middle")
+		assertExists(fc, "evt-newest")
+	})
 
-		Expect(promtestutil.ToFloat64(metrics.EventsCleanedTotal.WithLabelValues("controller"))-preCtrl).
-			To(Equal(float64(1)), "controller events cleanup should be counted")
-		Expect(promtestutil.ToFloat64(metrics.EventsCleanedTotal.WithLabelValues("webhook"))-preWebhook).
-			To(Equal(float64(1)), "webhook events cleanup should be counted")
+	It("groups by CRQ so one CRQ's trim does not affect another", func() {
+		now := time.Now()
+
+		fc := clientfake.NewClientBuilder().
+			WithScheme(newCleanupTestScheme()).
+			WithObjects(
+				makePACEvent("a-1", "quota-a", now.Add(-2*time.Hour)),
+				makePACEvent("a-2", "quota-a", now.Add(-1*time.Hour)),
+				makePACEvent("b-1", "quota-b", now.Add(-1*time.Hour)),
+			).
+			Build()
+
+		mgr := NewEventCleanupManager(fc, CleanupConfig{
+			MaxAge:          24 * time.Hour,
+			MaxEventsPerCRQ: 1,
+			CleanupInterval: time.Hour,
+			Enabled:         true,
+		}, logger)
+
+		Expect(mgr.cleanup(ctx)).To(Succeed())
+
+		assertGone(fc, "a-1") // quota-a trimmed to its newest
+		assertExists(fc, "a-2")
+		assertExists(fc, "b-1") // quota-b untouched (only one event)
 	})
 })

--- a/pkg/events/recorder.go
+++ b/pkg/events/recorder.go
@@ -22,11 +22,6 @@ const (
 	// Event types
 	EventTypeNormal  = "Normal"
 	EventTypeWarning = "Warning"
-
-	// Event labels for identification and cleanup
-	LabelEventSource = "quota.pac.io/event-source"
-	LabelEventType   = "quota.pac.io/event-type"
-	LabelCRQName     = "quota.pac.io/crq-name"
 )
 
 // EventRecorder wraps the Kubernetes event recorder with PAC-specific functionality

--- a/test/e2e/controller_events_test.go
+++ b/test/e2e/controller_events_test.go
@@ -2,47 +2,106 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	testutils "github.com/powerhome/pac-quota-controller/test/utils"
 )
 
-var _ = Describe("Controller Events E2E", Ordered, func() {
-	// TODO: These tests are currently skipped pending completion of lazy reader implementation
-	// The event recording system is working, but tests need to be updated to use efficient
-	// event watching via Kubernetes watch API instead of polling
+// crqEventReasons returns the reasons of all events recorded against the named CRQ.
+func crqEventReasons(crqName string) []string {
+	list := &eventsv1.EventList{}
+	if err := k8sClient.List(ctx, list); err != nil {
+		return nil
+	}
+	var reasons []string
+	for i := range list.Items {
+		if list.Items[i].Regarding.Name == crqName {
+			reasons = append(reasons, list.Items[i].Reason)
+		}
+	}
+	return reasons
+}
 
-	// TODO: Implement BeforeAll to set up test namespaces
-	// TODO: Implement AfterAll to clean up test namespaces
+var _ = Describe("Controller Events E2E", func() {
+	var suffix, team string
 
-	Describe("ClusterResourceQuota Event Generation", func() {
-		// TODO: Implement BeforeEach to set up test CRQ
-		// TODO: Implement AfterEach to clean up test CRQ
-
-		It("should generate NamespaceAdded and NamespaceRemoved events", func() {
-			// TODO: Implement lazy reader approach for watching events efficiently
-			// Current implementation has issues with event combining and pod-based event targeting
-			// Need to complete the CRQEventReader implementation and update helper functions
-			Skip("TODO: Complete lazy reader implementation for event watching")
-		})
-
-		It("should generate QuotaExceeded events when quota limits are violated", func() {
-			// TODO: Implement lazy reader approach for watching events efficiently
-			// Current test logic is correct (create pods first, then CRQ with exceeded limits)
-			// but needs the updated event watching implementation to work properly
-			Skip("TODO: Complete lazy reader implementation for event watching")
-		})
-
-		It("should generate InvalidSelector events for malformed selectors", func() {
-			// TODO: Implement lazy reader approach for watching events efficiently
-			// This test should work once the event watching implementation is completed
-			Skip("TODO: Complete lazy reader implementation for event watching")
-		})
+	BeforeEach(func() {
+		suffix = testutils.GenerateTestSuffix()
+		team = "evt-" + suffix
 	})
 
-	Describe("Event Metadata Validation", func() {
-		It("should include proper PAC-specific labels on events", func() {
-			// TODO: Update test to work with pod-based events and proper annotation checking
-			// Events are now recorded against controller pods with CRQ info in annotations
-			// Need to update validation logic to match the new event structure
-			Skip("TODO: Update event metadata validation for pod-based events")
-		})
+	It("emits NamespaceAdded then NamespaceRemoved as namespaces enter and leave scope", func() {
+		ns, err := testutils.CreateNamespace(ctx, k8sClient, "evt-ns-"+suffix, map[string]string{"team": team})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, ns) })
+
+		crq, err := testutils.CreateClusterResourceQuota(ctx, k8sClient, "evt-crq-"+suffix,
+			&metav1.LabelSelector{MatchLabels: map[string]string{"team": team}},
+			quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, crq) })
+
+		By("recording NamespaceAdded for the matching namespace")
+		Eventually(func() []string {
+			return crqEventReasons(crq.Name)
+		}, Timeout, Interval).Should(ContainElement("NamespaceAdded"))
+
+		By("relabeling the namespace out of scope")
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: ns.Name}, ns)).To(Succeed())
+		ns.Labels["team"] = "other-" + suffix
+		Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+
+		By("recording NamespaceRemoved once it leaves scope")
+		Eventually(func() []string {
+			return crqEventReasons(crq.Name)
+		}, Timeout, Interval).Should(ContainElement("NamespaceRemoved"))
+	})
+
+	It("emits QuotaExceeded when observed usage exceeds the hard limit", func() {
+		ns, err := testutils.CreateNamespace(ctx, k8sClient, "evt-exceed-ns-"+suffix, map[string]string{"team": team})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, ns) })
+
+		// Create two pods before any CRQ selects the namespace, so admission allows
+		// them; the CRQ created afterwards will observe usage above its limit.
+		for _, name := range []string{"evt-p1-" + suffix, "evt-p2-" + suffix} {
+			p, perr := testutils.CreatePod(ctx, k8sClient, ns.Name, name,
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")}, nil)
+			Expect(perr).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, p) })
+		}
+
+		crq, err := testutils.CreateClusterResourceQuota(ctx, k8sClient, "evt-exceed-crq-"+suffix,
+			&metav1.LabelSelector{MatchLabels: map[string]string{"team": team}},
+			quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, crq) })
+
+		By("recording QuotaExceeded for the over-limit resource")
+		Eventually(func() []string {
+			return crqEventReasons(crq.Name)
+		}, Timeout, Interval).Should(ContainElement("QuotaExceeded"))
+	})
+
+	// InvalidSelector is emitted only by the reconciler's defensive path. In a real
+	// cluster the CRQ admission webhook rejects a malformed selector before the
+	// object is ever stored, so this path is unreachable end-to-end. It is covered
+	// by the reconciler unit tests instead.
+	It("emits InvalidSelector events for malformed selectors", func() {
+		Skip("malformed selectors are rejected at admission; covered by reconciler unit tests")
+	})
+
+	// Events are recorded via the events.k8s.io API and carry no PAC labels today,
+	// so there is nothing to assert. NOTE: event cleanup (pkg/events) queries by the
+	// quota.pac.io/event-source label, which these events lack — tracked separately.
+	It("includes PAC-specific labels on events", func() {
+		Skip("events currently carry no PAC labels; recorder labeling is a separate fix")
 	})
 })

--- a/test/e2e/fail_open_test.go
+++ b/test/e2e/fail_open_test.go
@@ -1,0 +1,100 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	testutils "github.com/powerhome/pac-quota-controller/test/utils"
+)
+
+const (
+	controllerNamespace  = "pac-quota-controller-system"
+	controllerDeployment = "pac-quota-controller-manager"
+)
+
+var _ = Describe("Webhook fail-open behavior", Ordered, func() {
+	var (
+		suffix string
+		ns     *corev1.Namespace
+		crq    *quotav1alpha1.ClusterResourceQuota
+		depKey = client.ObjectKey{Namespace: controllerNamespace, Name: controllerDeployment}
+	)
+
+	scaleController := func(replicas int32) {
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, depKey, dep)).To(Succeed())
+		dep.Spec.Replicas = &replicas
+		Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		suffix = testutils.GenerateTestSuffix()
+		team := "failopen-" + suffix
+
+		var err error
+		ns, err = testutils.CreateNamespace(ctx, k8sClient, "failopen-ns-"+suffix, map[string]string{"team": team})
+		Expect(err).NotTo(HaveOccurred())
+
+		// pods quota of 1: a second pod would normally be denied at admission.
+		crq, err = testutils.CreateClusterResourceQuota(ctx, k8sClient, "failopen-crq-"+suffix,
+			&metav1.LabelSelector{MatchLabels: map[string]string{"team": team}},
+			quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, crq)
+		_ = k8sClient.Delete(ctx, ns)
+	})
+
+	It("admits an over-quota pod while the controller is unavailable", func() {
+		// Fill the pods=1 quota and wait for the controller to record it, so the
+		// webhook would deny the next pod if it were reachable.
+		p1, err := testutils.CreatePod(ctx, k8sClient, ns.Name, "pod-1-"+suffix,
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, p1) })
+
+		Eventually(func() error {
+			usage := testutils.GetRefreshedCRQStatusUsage(ctx, k8sClient, crq.Name)
+			return testutils.ExpectCRQUsageToMatch(usage, map[string]string{"pods": "1"})
+		}, Timeout, Interval).Should(Succeed())
+
+		// Capture the current replica count and scale the controller down.
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, depKey, dep)).To(Succeed())
+		original := *dep.Spec.Replicas
+		DeferCleanup(func() {
+			scaleController(original)
+			Eventually(func() int32 {
+				restored := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, depKey, restored)).To(Succeed())
+				return restored.Status.AvailableReplicas
+			}, Timeout, Interval).Should(BeNumerically(">=", 1))
+		})
+
+		By("scaling the controller (and its webhook) to zero")
+		scaleController(0)
+		Eventually(func() int32 {
+			down := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, depKey, down)).To(Succeed())
+			return down.Status.ReadyReplicas
+		}, Timeout, Interval).Should(BeZero())
+
+		By("admitting a pod that would exceed the quota (failurePolicy: Ignore)")
+		var p2 *corev1.Pod
+		Eventually(func() error {
+			p2, err = testutils.CreatePod(ctx, k8sClient, ns.Name, "pod-2-"+suffix,
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}, nil)
+			return err
+		}, Timeout, Interval).Should(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, p2) })
+	})
+})

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -1,0 +1,74 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	testutils "github.com/powerhome/pac-quota-controller/test/utils"
+)
+
+var _ = Describe("ClusterResourceQuota multi-namespace aggregation", func() {
+	var (
+		suffix string
+		team   string
+		crq    *quotav1alpha1.ClusterResourceQuota
+		ns1    *corev1.Namespace
+		ns2    *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		suffix = testutils.GenerateTestSuffix()
+		team = "multi-" + suffix
+
+		var err error
+		ns1, err = testutils.CreateNamespace(ctx, k8sClient, "multi-ns1-"+suffix, map[string]string{"team": team})
+		Expect(err).NotTo(HaveOccurred())
+		ns2, err = testutils.CreateNamespace(ctx, k8sClient, "multi-ns2-"+suffix, map[string]string{"team": team})
+		Expect(err).NotTo(HaveOccurred())
+
+		crq, err = testutils.CreateClusterResourceQuota(ctx, k8sClient, "multi-crq-"+suffix,
+			&metav1.LabelSelector{MatchLabels: map[string]string{"team": team}},
+			quotav1alpha1.ResourceList{
+				corev1.ResourceRequestsCPU: resource.MustParse("10"),
+				corev1.ResourcePods:        resource.MustParse("10"),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, crq)
+		_ = k8sClient.Delete(ctx, ns1)
+		_ = k8sClient.Delete(ctx, ns2)
+	})
+
+	It("sums usage across all selected namespaces into the CRQ total", func() {
+		p1, err := testutils.CreatePod(ctx, k8sClient, ns1.Name, "pod1-"+suffix,
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, p1) })
+
+		p2, err := testutils.CreatePod(ctx, k8sClient, ns2.Name, "pod2-"+suffix,
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, p2) })
+
+		By("aggregating usage from both namespaces into status.total")
+		Eventually(func() error {
+			usage := testutils.GetRefreshedCRQStatusUsage(ctx, k8sClient, crq.Name)
+			return testutils.ExpectCRQUsageToMatch(usage, map[string]string{
+				"requests.cpu": "800m", // 500m (ns1) + 300m (ns2)
+				"pods":         "2",
+			})
+		}, Timeout, Interval).Should(Succeed())
+
+		By("reporting both namespaces in status")
+		Eventually(func() []string {
+			return testutils.GetRefreshedCRQStatusNamespaces(ctx, k8sClient, crq.Name)
+		}, Timeout, Interval).Should(ContainElements(ns1.Name, ns2.Name))
+	})
+})


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Closes high-value end-to-end coverage gaps for the ClusterResourceQuota controller, and fixes an event-cleanup bug found while doing so. All e2e specs run via the `go test` harness (no Makefile orchestration).

### e2e coverage
- **Multi-namespace aggregation** (`multi_namespace_test.go`): the controller's core promise — usage from pods in two+ selected namespaces is summed into `status.total`, and both namespaces appear in `status.namespaces`.
- **Webhook fail-open** (`fail_open_test.go`): fills a `pods: 1` quota, scales the controller (and its webhook) to zero, and asserts an over-quota pod is **admitted** — pinning the deployed `failurePolicy: Ignore` behavior. Restores the controller on cleanup.
- **Events** (`controller_events_test.go`): implemented the two reachable specs — `NamespaceAdded`→`NamespaceRemoved` and `QuotaExceeded` (queried by event `Reason` + `Regarding`). The other two are skipped with accurate reasons: `InvalidSelector` is unreachable e2e (admission webhook rejects malformed selectors; covered by unit tests), and PAC event labels do not exist.

### Bug fix: event cleanup matched nothing
Events are recorded via the `events.k8s.io` API, which does not attach the `quota.pac.io/*` labels the cleanup loop queried on — so TTL/max-events cleanup found and deleted **nothing**, and the webhook "source" it queried never emits events. Reworked `pkg/events` cleanup to identify PAC events by their `Regarding` (the CRQ — always present) and group by `Regarding.Name`, dropping the dead label scheme. Added unit tests for expiry, max-events trimming, and per-CRQ grouping.

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

_Not applicable — tests + internal fix only._

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
  - e2e validated on a live kind cluster (aggregation, fail-open, NamespaceAdded/Removed, QuotaExceeded — all pass).
  - `pkg/events` unit tests: expiry deletion + count, max-events trim, per-CRQ grouping.
- [ ] 📚 Updated documentation and Helm chart _(n/a)_
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `go vet` + `golangci-lint run` clean
  - [x] e2e focused specs green against kind

### Versioning & Release

- [ ] 📊 Bumped chart `version` _(n/a — no chart change)_
- [ ] 🏷️ Bumped `appVersion` _(n/a)_
- [ ] 🔖 Tagged the release _(n/a)_
