### PR TITLE
test(infra): cover certwatcher, logger, metrics, utils

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -84,6 +84,71 @@ var _ = Describe("InitConfig", func() {
 	})
 })
 
+var _ = Describe("InitConfig extended fields", func() {
+	BeforeEach(func() {
+		viper.Reset()
+	})
+	AfterEach(func() {
+		viper.Reset()
+	})
+
+	It("parses excluded-namespaces, trimming spaces and skipping empties", func() {
+		Expect(os.Setenv("EXCLUDED_NAMESPACES", "ns1, ns2 ,, ns3")).To(Succeed())
+		DeferCleanup(func() { _ = os.Unsetenv("EXCLUDED_NAMESPACES") })
+
+		viper.Reset()
+		cfg := InitConfig()
+		Expect(cfg.ExcludedNamespaces).To(Equal([]string{"ns1", "ns2", "ns3"}))
+	})
+
+	It("leaves excluded-namespaces empty when unset", func() {
+		viper.Reset()
+		cfg := InitConfig()
+		Expect(cfg.ExcludedNamespaces).To(BeEmpty())
+	})
+
+	It("defaults the leader-election timings", func() {
+		viper.Reset()
+		cfg := InitConfig()
+		Expect(cfg.LeaderElectionLeaseDuration).To(Equal(60))
+		Expect(cfg.LeaderElectionRenewDeadline).To(Equal(40))
+		Expect(cfg.LeaderElectionRetryPeriod).To(Equal(10))
+	})
+
+	It("defaults the events configuration", func() {
+		viper.Reset()
+		cfg := InitConfig()
+		Expect(cfg.EventsEnable).To(BeTrue())
+		Expect(cfg.EventsTTL).To(Equal("24h"))
+		Expect(cfg.EventsMaxEventsPerCRQ).To(Equal(100))
+		Expect(cfg.EventsCleanupInterval).To(Equal("1h"))
+	})
+
+	It("reads events configuration from the environment", func() {
+		envVars := map[string]string{
+			"EVENTS_ENABLE":             "false",
+			"EVENTS_TTL":                "48h",
+			"EVENTS_MAX_EVENTS_PER_CRQ": "50",
+			"EVENTS_CLEANUP_INTERVAL":   "30m",
+		}
+		for k, v := range envVars {
+			Expect(os.Setenv(k, v)).To(Succeed())
+		}
+		DeferCleanup(func() {
+			for k := range envVars {
+				_ = os.Unsetenv(k)
+			}
+		})
+
+		viper.Reset()
+		cfg := InitConfig()
+		Expect(cfg.EventsEnable).To(BeFalse())
+		Expect(cfg.EventsTTL).To(Equal("48h"))
+		Expect(cfg.EventsMaxEventsPerCRQ).To(Equal(50))
+		Expect(cfg.EventsCleanupInterval).To(Equal("30m"))
+	})
+})
+
 var _ = Describe("SetupFlags", func() {
 	var cmd *cobra.Command
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,59 @@
+package logger
+
+import (
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/powerhome/pac-quota-controller/pkg/config"
+)
+
+func TestSetupLoggerLevels(t *testing.T) {
+	cases := []struct {
+		level   string
+		enabled zapcore.Level
+		blocked zapcore.Level
+	}{
+		{"debug", zapcore.DebugLevel, 0},
+		{"info", zapcore.InfoLevel, zapcore.DebugLevel},
+		{"warn", zapcore.WarnLevel, zapcore.InfoLevel},
+		{"error", zapcore.ErrorLevel, zapcore.WarnLevel},
+		{"unknown-defaults-to-info", zapcore.InfoLevel, zapcore.DebugLevel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.level, func(t *testing.T) {
+			lg := SetupLogger(&config.Config{LogLevel: tc.level, LogFormat: "json"})
+			if lg == nil {
+				t.Fatal("SetupLogger returned nil")
+			}
+			if !lg.Core().Enabled(tc.enabled) {
+				t.Errorf("expected level %v to be enabled", tc.enabled)
+			}
+			if tc.blocked != 0 && lg.Core().Enabled(tc.blocked) {
+				t.Errorf("expected level %v to be disabled", tc.blocked)
+			}
+		})
+	}
+}
+
+func TestSetupLoggerConsoleFormat(t *testing.T) {
+	if SetupLogger(&config.Config{LogLevel: "info", LogFormat: "console"}) == nil {
+		t.Fatal("SetupLogger returned nil for console format")
+	}
+}
+
+func TestLAlwaysReturnsLogger(t *testing.T) {
+	if L() == nil {
+		t.Fatal("L() must never return nil")
+	}
+}
+
+func TestInitTestSetsGlobalLogger(t *testing.T) {
+	lg := InitTest()
+	if lg == nil {
+		t.Fatal("InitTest returned nil")
+	}
+	if L() != lg {
+		t.Fatal("L() should return the logger set by InitTest")
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "testing"
+
+// RegisterWebhookMetrics uses MustRegister, which panics on duplicate registration.
+// registerOnce must make repeated calls safe.
+func TestRegisterWebhookMetricsIdempotent(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RegisterWebhookMetrics panicked on repeat call: %v", r)
+		}
+	}()
+	RegisterWebhookMetrics()
+	RegisterWebhookMetrics()
+	RegisterWebhookMetrics()
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -39,3 +39,31 @@ var _ = Describe("DeduplicateAndSort", func() {
 		Expect(result).To(Equal(expected))
 	})
 })
+
+var _ = Describe("EqualStringMap", func() {
+	It("returns true for two nil maps", func() {
+		Expect(EqualStringMap(nil, nil)).To(BeTrue())
+	})
+
+	It("treats nil and empty maps as equal", func() {
+		Expect(EqualStringMap(nil, map[string]string{})).To(BeTrue())
+	})
+
+	It("returns true for equal maps", func() {
+		a := map[string]string{"x": "1", "y": "2"}
+		b := map[string]string{"y": "2", "x": "1"}
+		Expect(EqualStringMap(a, b)).To(BeTrue())
+	})
+
+	It("returns false when lengths differ", func() {
+		Expect(EqualStringMap(map[string]string{"x": "1"}, map[string]string{"x": "1", "y": "2"})).To(BeFalse())
+	})
+
+	It("returns false when a value differs", func() {
+		Expect(EqualStringMap(map[string]string{"x": "1"}, map[string]string{"x": "2"})).To(BeFalse())
+	})
+
+	It("returns false when a key is missing", func() {
+		Expect(EqualStringMap(map[string]string{"x": "1"}, map[string]string{"y": "1"})).To(BeFalse())
+	})
+})

--- a/pkg/webhook/certwatcher/certwatcher_test.go
+++ b/pkg/webhook/certwatcher/certwatcher_test.go
@@ -1,0 +1,258 @@
+package certwatcher
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"gopkg.in/fsnotify.v1"
+)
+
+// writeCertPair generates a self-signed cert/key pair into dir and returns their paths.
+func writeCertPair(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "certwatcher-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	writePEM(t, certPath, "CERTIFICATE", der)
+	writePEM(t, keyPath, "EC PRIVATE KEY", keyDER)
+	return certPath, keyPath
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func newWatcher(t *testing.T, certPath, keyPath string) *CertWatcher {
+	t.Helper()
+	cw, err := NewCertWatcher(certPath, keyPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewCertWatcher: %v", err)
+	}
+	t.Cleanup(cw.Stop)
+	return cw
+}
+
+func TestNewCertWatcher(t *testing.T) {
+	cw, err := NewCertWatcher("/no/cert", "/no/key", zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cw.Stop()
+	if cw.watcher == nil || cw.reloadChan == nil || cw.stopChan == nil {
+		t.Fatal("watcher not fully initialized")
+	}
+}
+
+func TestLoadCertificate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, keyPath)
+
+		if err := cw.loadCertificate(); err != nil {
+			t.Fatalf("loadCertificate: %v", err)
+		}
+		got, err := cw.GetCertificate(nil)
+		if err != nil || got == nil {
+			t.Fatalf("GetCertificate after load: cert=%v err=%v", got, err)
+		}
+	})
+
+	t.Run("missing cert file", func(t *testing.T) {
+		dir := t.TempDir()
+		_, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, filepath.Join(dir, "absent.crt"), keyPath)
+		if err := cw.loadCertificate(); err == nil {
+			t.Fatal("expected error for missing cert file")
+		}
+	})
+
+	t.Run("missing key file", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, _ := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, filepath.Join(dir, "absent.key"))
+		if err := cw.loadCertificate(); err == nil {
+			t.Fatal("expected error for missing key file")
+		}
+	})
+
+	t.Run("malformed cert PEM", func(t *testing.T) {
+		dir := t.TempDir()
+		_, keyPath := writeCertPair(t, dir)
+		certPath := filepath.Join(dir, "bad.crt")
+		if err := os.WriteFile(certPath, []byte("not a pem"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cw := newWatcher(t, certPath, keyPath)
+		if err := cw.loadCertificate(); err == nil {
+			t.Fatal("expected decode error for malformed cert PEM")
+		}
+	})
+
+	t.Run("malformed key PEM", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, _ := writeCertPair(t, dir)
+		keyPath := filepath.Join(dir, "bad.key")
+		if err := os.WriteFile(keyPath, []byte("not a pem"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cw := newWatcher(t, certPath, keyPath)
+		if err := cw.loadCertificate(); err == nil {
+			t.Fatal("expected decode error for malformed key PEM")
+		}
+	})
+}
+
+func TestGetCertificateNoCert(t *testing.T) {
+	cw := newWatcher(t, "/no/cert", "/no/key")
+	if _, err := cw.GetCertificate(nil); err == nil {
+		t.Fatal("expected error when no certificate is loaded")
+	}
+}
+
+func TestWaitForCertificateFiles(t *testing.T) {
+	t.Run("loads when files are present", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, keyPath)
+		if err := cw.waitForCertificateFiles(context.Background(), 3, time.Millisecond); err != nil {
+			t.Fatalf("waitForCertificateFiles: %v", err)
+		}
+	})
+
+	t.Run("times out when files never appear", func(t *testing.T) {
+		cw := newWatcher(t, "/no/cert", "/no/key")
+		if err := cw.waitForCertificateFiles(context.Background(), 2, time.Millisecond); err == nil {
+			t.Fatal("expected timeout error")
+		}
+	})
+
+	t.Run("returns on context cancellation", func(t *testing.T) {
+		cw := newWatcher(t, "/no/cert", "/no/key")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := cw.waitForCertificateFiles(ctx, 5, time.Hour); err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
+}
+
+func TestHandleFileEvent(t *testing.T) {
+	t.Run("ignores unrelated files", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, keyPath)
+		cw.handleFileEvent(fsnotify.Event{Name: filepath.Join(dir, "other"), Op: fsnotify.Write})
+		if _, err := cw.GetCertificate(nil); err == nil {
+			t.Fatal("unrelated file should not have triggered a load")
+		}
+	})
+
+	t.Run("ignores non-write operations", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, keyPath)
+		cw.handleFileEvent(fsnotify.Event{Name: certPath, Op: fsnotify.Chmod})
+		if _, err := cw.GetCertificate(nil); err == nil {
+			t.Fatal("non-write op should not have triggered a load")
+		}
+	})
+
+	t.Run("reloads and signals on write", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, keyPath)
+
+		cw.handleFileEvent(fsnotify.Event{Name: certPath, Op: fsnotify.Write})
+
+		select {
+		case <-cw.GetReloadChannel():
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a reload signal after a write event")
+		}
+		if _, err := cw.GetCertificate(nil); err != nil {
+			t.Fatalf("certificate should be loaded after reload: %v", err)
+		}
+	})
+}
+
+func TestGetCertificateInfo(t *testing.T) {
+	t.Run("errors when no certificate", func(t *testing.T) {
+		cw := newWatcher(t, "/no/cert", "/no/key")
+		if _, err := cw.GetCertificateInfo(); err == nil {
+			t.Fatal("expected error when no certificate is loaded")
+		}
+	})
+
+	t.Run("returns info once loaded", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeCertPair(t, dir)
+		cw := newWatcher(t, certPath, keyPath)
+		if err := cw.loadCertificate(); err != nil {
+			t.Fatalf("loadCertificate: %v", err)
+		}
+		info, err := cw.GetCertificateInfo()
+		if err != nil {
+			t.Fatalf("GetCertificateInfo: %v", err)
+		}
+		if info.Subject != "certwatcher-test" {
+			t.Fatalf("unexpected subject %q", info.Subject)
+		}
+	})
+}
+
+func TestStartAndStop(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeCertPair(t, dir)
+	cw, err := NewCertWatcher(certPath, keyPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewCertWatcher: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := cw.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := cw.GetCertificate(nil); err != nil {
+		t.Fatalf("certificate should be loaded after Start: %v", err)
+	}
+
+	// Stop must be safe to call more than once.
+	cw.Stop()
+	cw.Stop()
+}


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Adds unit coverage for infrastructure packages that previously had little or no testing. No production code changes.

- **certwatcher** (`pkg/webhook/certwatcher`) — had **no test file** at all; this is the TLS cert hot-reload core of the admission webhook. Covered: `loadCertificate` (success + missing/malformed cert and key PEM), `GetCertificate` (no-cert error + loaded), `waitForCertificateFiles` (present / timeout / context-cancel), `handleFileEvent` (ignores unrelated files and non-write ops; reloads + signals on write), `GetCertificateInfo`, and `Start`/`Stop` (incl. double-`Stop` safety). 0% → ~86%.
- **pkg/utils** — `EqualStringMap` had zero tests (nil/empty/equal/length/value/key cases). → 100%.
- **pkg/logger** — `SetupLogger` level + format branches, `L()` non-nil guarantee, `InitTest`. → ~91%.
- **pkg/metrics** — `RegisterWebhookMetrics` idempotency (`registerOnce` guards `MustRegister` against panic on repeat calls). → 100%.
- **pkg/config** — `excluded-namespaces` parsing (trim + skip-empty), events configuration defaults + env overrides, and leader-election timing defaults. → ~97%.

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

_Not applicable — tests only._

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart _(n/a)_
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `go test` (envtest-free packages) + `golangci-lint run` clean
  - [ ] `make test-e2e` _(unaffected — unit-test-only change)_

### Versioning & Release

- [ ] 📊 Bumped chart `version` _(n/a — no chart change)_
- [ ] 🏷️ Bumped `appVersion` _(n/a)_
- [ ] 🔖 Tagged the release _(n/a)_
