### PR TITLE
Test/cmd coverage

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,118 +21,123 @@ import (
 	"github.com/powerhome/pac-quota-controller/pkg/webhook"
 )
 
-// nolint:gocyclo
 func main() {
-	// Create root command
+	if err := newRootCommand().Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// newRootCommand builds the controller-manager command tree (root + version),
+// wiring flags. Running the root with no subcommand starts the manager.
+func newRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "controller-manager",
 		Short: "Cluster Resource Quota controller manager",
 		Long:  "Manages ClusterResourceQuota resources that provide quota limits across multiple namespaces",
 		Run: func(cmd *cobra.Command, args []string) {
-			// Initialize configuration
-			cfg := config.InitConfig()
-
-			// Set up logging
-			pkglogger.Initialize(cfg)
-			logger := pkglogger.L()
-			defer func() {
-				if err := logger.Sync(); err != nil {
-					logger.Error("Failed to sync logger", zap.Error(err))
-				}
-			}()
-			// fatal exits 1 after flushing the logger so the last error line is
-			// guaranteed to surface even when os.Exit short-circuits the defers.
-			fatal := func() {
-				_ = logger.Sync()
-				os.Exit(1)
-			}
-
-			// Configure controller-runtime logger to use zap for consistent JSON formatting
-			ctrl.SetLogger(zapctrl.New(zapctrl.UseDevMode(false), zapctrl.JSONEncoder()))
-
-			// Use controller-runtime's signal handler — cancels context on SIGTERM/SIGINT
-			ctx := ctrl.SetupSignalHandler()
-
-			// Initialize scheme
-			scheme := manager.InitScheme()
-
-			// Create controller manager
-			mgr, err := manager.SetupManager(cfg, scheme)
-			if err != nil {
-				logger.Error("unable to start manager", zap.Error(err))
-				fatal()
-			}
-
-			// Set up controllers
-			if err := manager.SetupControllers(ctx, mgr, cfg, logger); err != nil {
-				logger.Error("unable to set up controllers", zap.Error(err))
-				fatal()
-			}
-
-			// Create kubernetes clientset for webhook server
-			clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
-			if err != nil {
-				logger.Error("unable to create kubernetes clientset", zap.Error(err))
-				fatal()
-			}
-
-			// Set up Gin webhook server with manager's client for CRQ operations
-			webhookServer, webhookCertWatcher := webhook.SetupGinWebhookServer(cfg, clientset, mgr.GetClient(), logger)
-
-			// Start webhook server and cert watcher in background goroutines.
-			// They respect context cancellation via <-ctx.Done() for graceful shutdown.
-			go func() {
-				if err := webhookServer.Start(ctx); err != nil {
-					logger.Error("webhook server failed", zap.Error(err))
-				}
-			}()
-
-			if webhookCertWatcher != nil {
-				go func() {
-					if err := webhookCertWatcher.Start(ctx); err != nil {
-						logger.Error("webhook certificate watcher failed", zap.Error(err))
-					}
-				}()
-			}
-
-			// Flip the webhook's cache-sync readiness gate once the manager's
-			// informer cache has finished initial sync. Until then /readyz
-			// returns 503 so the apiserver does not route admission traffic to
-			// a webhook whose CRQ lookups would hit a cold cache.
-			go func() {
-				if mgr.GetCache().WaitForCacheSync(ctx) {
-					webhookServer.MarkCacheSynced()
-				} else {
-					logger.Error("informer cache failed to sync; webhook /readyz will stay 503")
-				}
-			}()
-
-			// Log when manager is elected as leader
-			go func() {
-				<-mgr.Elected()
-				logger.Info("Controller manager elected as leader and ready to process resources")
-			}()
-
-			// Start the manager synchronously. This blocks until the context is cancelled
-			// (SIGTERM/SIGINT) or the manager fails (e.g. leader election lost).
-			// When it returns, the process exits — no zombie state possible.
-			logger.Info("Starting controller manager")
-			if err := mgr.Start(ctx); err != nil {
-				logger.Error("controller manager failed", zap.Error(err))
-				fatal()
-			}
+			runManager()
 		},
 	}
-
-	// Add version command
 	rootCmd.AddCommand(version.NewVersionCmd())
-
-	// Setup flags
 	config.SetupFlags(rootCmd)
+	return rootCmd
+}
 
-	// Execute the root command
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+// runManager wires and starts the controller manager and webhook server,
+// blocking until the context is cancelled (SIGTERM/SIGINT) or the manager fails.
+// nolint:gocyclo
+func runManager() {
+	// Initialize configuration
+	cfg := config.InitConfig()
+
+	// Set up logging
+	pkglogger.Initialize(cfg)
+	logger := pkglogger.L()
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			logger.Error("Failed to sync logger", zap.Error(err))
+		}
+	}()
+	// fatal exits 1 after flushing the logger so the last error line is
+	// guaranteed to surface even when os.Exit short-circuits the defers.
+	fatal := func() {
+		_ = logger.Sync()
 		os.Exit(1)
+	}
+
+	// Configure controller-runtime logger to use zap for consistent JSON formatting
+	ctrl.SetLogger(zapctrl.New(zapctrl.UseDevMode(false), zapctrl.JSONEncoder()))
+
+	// Use controller-runtime's signal handler — cancels context on SIGTERM/SIGINT
+	ctx := ctrl.SetupSignalHandler()
+
+	// Initialize scheme
+	scheme := manager.InitScheme()
+
+	// Create controller manager
+	mgr, err := manager.SetupManager(cfg, scheme)
+	if err != nil {
+		logger.Error("unable to start manager", zap.Error(err))
+		fatal()
+	}
+
+	// Set up controllers
+	if err := manager.SetupControllers(ctx, mgr, cfg, logger); err != nil {
+		logger.Error("unable to set up controllers", zap.Error(err))
+		fatal()
+	}
+
+	// Create kubernetes clientset for webhook server
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		logger.Error("unable to create kubernetes clientset", zap.Error(err))
+		fatal()
+	}
+
+	// Set up Gin webhook server with manager's client for CRQ operations
+	webhookServer, webhookCertWatcher := webhook.SetupGinWebhookServer(cfg, clientset, mgr.GetClient(), logger)
+
+	// Start webhook server and cert watcher in background goroutines.
+	// They respect context cancellation via <-ctx.Done() for graceful shutdown.
+	go func() {
+		if err := webhookServer.Start(ctx); err != nil {
+			logger.Error("webhook server failed", zap.Error(err))
+		}
+	}()
+
+	if webhookCertWatcher != nil {
+		go func() {
+			if err := webhookCertWatcher.Start(ctx); err != nil {
+				logger.Error("webhook certificate watcher failed", zap.Error(err))
+			}
+		}()
+	}
+
+	// Flip the webhook's cache-sync readiness gate once the manager's
+	// informer cache has finished initial sync. Until then /readyz
+	// returns 503 so the apiserver does not route admission traffic to
+	// a webhook whose CRQ lookups would hit a cold cache.
+	go func() {
+		if mgr.GetCache().WaitForCacheSync(ctx) {
+			webhookServer.MarkCacheSynced()
+		} else {
+			logger.Error("informer cache failed to sync; webhook /readyz will stay 503")
+		}
+	}()
+
+	// Log when manager is elected as leader
+	go func() {
+		<-mgr.Elected()
+		logger.Info("Controller manager elected as leader and ready to process resources")
+	}()
+
+	// Start the manager synchronously. This blocks until the context is cancelled
+	// (SIGTERM/SIGINT) or the manager fails (e.g. leader election lost).
+	// When it returns, the process exits — no zombie state possible.
+	logger.Info("Starting controller manager")
+	if err := mgr.Start(ctx); err != nil {
+		logger.Error("controller manager failed", zap.Error(err))
+		fatal()
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestNewRootCommand(t *testing.T) {
+	cmd := newRootCommand()
+
+	if cmd.Use != "controller-manager" {
+		t.Errorf("unexpected Use %q", cmd.Use)
+	}
+
+	hasVersion := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "version" {
+			hasVersion = true
+		}
+	}
+	if !hasVersion {
+		t.Error("version subcommand not registered")
+	}
+
+	for _, flag := range []string{"leader-elect", "log-level", "webhook-port", "events-enable"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("flag %q not registered", flag)
+		}
+	}
+}
+
+// Executing the version subcommand exercises the command wiring without starting
+// the manager (which would require a real cluster).
+func TestRootCommandRunsVersionSubcommand(t *testing.T) {
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"version"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("executing version subcommand: %v", err)
+	}
+}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,18 @@
+package version
+
+import "testing"
+
+func TestNewVersionCmd(t *testing.T) {
+	cmd := NewVersionCmd()
+	if cmd.Use != "version" {
+		t.Errorf("unexpected Use %q", cmd.Use)
+	}
+	if cmd.Run == nil {
+		t.Error("version command has no Run function")
+	}
+}
+
+func TestPrintInfo(t *testing.T) {
+	// Smoke test: PrintInfo writes build info to stdout and must not panic.
+	PrintInfo()
+}


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

<!--
Provide a detailed description of your changes:
- What problem does this solve?
- How did you solve it?
- What are the key changes?
- Why did you choose this approach?
-->
This pull request introduces several improvements and updates across the codebase, focusing on enhanced Prometheus alerting, a refactor of the CLI entrypoint for better testability, and some cleanup of test and configuration files. The most significant changes are the addition of new Prometheus alert rules, a refactor of the `main.go` command structure with accompanying tests, and updates to Helm chart documentation and configuration.

**Prometheus Alerting Enhancements:**

- Added two new alerting rules to Prometheus: one for detecting spikes in webhook denials due to bad requests (indicating possible webhook bugs), and another for detecting when the events cleanup loop has stalled. These rules are configurable via Helm values and documented in the chart README. [[1]](diffhunk://#diff-a926036bfca14e5c38cbaccf5d5db7135b58f43f2f84ecdee0292b7aab446e73R58-R81) [[2]](diffhunk://#diff-01fe579fbff3ab22098016f8f2d040e3f7c24620d9962266e9de28d1c621f6f4R129-R142) [[3]](diffhunk://#diff-3d3a1ac0f55a273a8b76136fefd736eed559a2e74ec6e401babdea7be93b9b20R323-R325) [[4]](diffhunk://#diff-3d3a1ac0f55a273a8b76136fefd736eed559a2e74ec6e401babdea7be93b9b20R334-R336)
- Updated the QuotaBreached alert description to remove the list of namespaces for brevity.

**CLI Entrypoint Refactor and Testing:**

- Refactored `main.go` to extract CLI command construction into a `newRootCommand` function, improving testability and separation of concerns. Introduced a `runManager` function to encapsulate the manager startup logic. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L24-R50) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R62-R67) [[3]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L57-R95) [[4]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R117-R128) [[5]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L104-R141)
- Added unit tests for the CLI command wiring in `cmd/main_test.go` and for the version subcommand in `cmd/version/version_test.go`. [[1]](diffhunk://#diff-de0b58ad38a2e0934640a3bfcc6f1e7431b18830d5eab615014278d2a7481451R1-R37) [[2]](diffhunk://#diff-a6e9cedf36ae1f9b807d361a421ec6a917637b9e11630fde62ded50f8b547d85R1-R18)

**Helm Chart and Documentation Updates:**

- Bumped the Helm chart version to 0.4.5 and updated the README badge accordingly. [[1]](diffhunk://#diff-346cec95f1bf647a7c17d20653e0188c76de8770a9527a7c36fe666ad23bc6c1L5-R5) [[2]](diffhunk://#diff-3d3a1ac0f55a273a8b76136fefd736eed559a2e74ec6e401babdea7be93b9b20L3-R3)
- Increased the default `terminationGracePeriodSeconds` for the controller manager to 35s to align with the webhook server's graceful shutdown period. [[1]](diffhunk://#diff-01fe579fbff3ab22098016f8f2d040e3f7c24620d9962266e9de28d1c621f6f4L73-R76) [[2]](diffhunk://#diff-3d3a1ac0f55a273a8b76136fefd736eed559a2e74ec6e401babdea7be93b9b20L311-R311)

**Test and Workflow Cleanup:**

- Simplified the e2e test Makefile targets to delegate cluster lifecycle management to the Go test suite, removing redundant setup and cleanup steps.
- Removed unused mockery configuration for deprecated or removed packages.
- Removed the `kind create cluster` step from the e2e GitHub Actions workflow, likely as part of shifting cluster management responsibilities.

**Dependency Updates:**

- Added `github.com/kylelemons/godebug` as an indirect dependency in `go.mod`.

## 📚 Documentation

<!--
Describe documentation changes:
- Updated README
- Added new docs
- Updated API documentation

-->

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [ ] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [ ] 🔧 Ran pre-commit hooks to validate changes:
  - [ ] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **📝 Note:** Chart and app versioning are manual. See CONTRIBUTING.md for details on how to release.
> **🐙 Note:** For Helm chart installation, use GHCR as an OCI registry. See README for instructions.
