### PR TITLE
Test/cmd coverage

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,118 +21,123 @@ import (
 	"github.com/powerhome/pac-quota-controller/pkg/webhook"
 )
 
-// nolint:gocyclo
 func main() {
-	// Create root command
+	if err := newRootCommand().Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// newRootCommand builds the controller-manager command tree (root + version),
+// wiring flags. Running the root with no subcommand starts the manager.
+func newRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "controller-manager",
 		Short: "Cluster Resource Quota controller manager",
 		Long:  "Manages ClusterResourceQuota resources that provide quota limits across multiple namespaces",
 		Run: func(cmd *cobra.Command, args []string) {
-			// Initialize configuration
-			cfg := config.InitConfig()
-
-			// Set up logging
-			pkglogger.Initialize(cfg)
-			logger := pkglogger.L()
-			defer func() {
-				if err := logger.Sync(); err != nil {
-					logger.Error("Failed to sync logger", zap.Error(err))
-				}
-			}()
-			// fatal exits 1 after flushing the logger so the last error line is
-			// guaranteed to surface even when os.Exit short-circuits the defers.
-			fatal := func() {
-				_ = logger.Sync()
-				os.Exit(1)
-			}
-
-			// Configure controller-runtime logger to use zap for consistent JSON formatting
-			ctrl.SetLogger(zapctrl.New(zapctrl.UseDevMode(false), zapctrl.JSONEncoder()))
-
-			// Use controller-runtime's signal handler — cancels context on SIGTERM/SIGINT
-			ctx := ctrl.SetupSignalHandler()
-
-			// Initialize scheme
-			scheme := manager.InitScheme()
-
-			// Create controller manager
-			mgr, err := manager.SetupManager(cfg, scheme)
-			if err != nil {
-				logger.Error("unable to start manager", zap.Error(err))
-				fatal()
-			}
-
-			// Set up controllers
-			if err := manager.SetupControllers(ctx, mgr, cfg, logger); err != nil {
-				logger.Error("unable to set up controllers", zap.Error(err))
-				fatal()
-			}
-
-			// Create kubernetes clientset for webhook server
-			clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
-			if err != nil {
-				logger.Error("unable to create kubernetes clientset", zap.Error(err))
-				fatal()
-			}
-
-			// Set up Gin webhook server with manager's client for CRQ operations
-			webhookServer, webhookCertWatcher := webhook.SetupGinWebhookServer(cfg, clientset, mgr.GetClient(), logger)
-
-			// Start webhook server and cert watcher in background goroutines.
-			// They respect context cancellation via <-ctx.Done() for graceful shutdown.
-			go func() {
-				if err := webhookServer.Start(ctx); err != nil {
-					logger.Error("webhook server failed", zap.Error(err))
-				}
-			}()
-
-			if webhookCertWatcher != nil {
-				go func() {
-					if err := webhookCertWatcher.Start(ctx); err != nil {
-						logger.Error("webhook certificate watcher failed", zap.Error(err))
-					}
-				}()
-			}
-
-			// Flip the webhook's cache-sync readiness gate once the manager's
-			// informer cache has finished initial sync. Until then /readyz
-			// returns 503 so the apiserver does not route admission traffic to
-			// a webhook whose CRQ lookups would hit a cold cache.
-			go func() {
-				if mgr.GetCache().WaitForCacheSync(ctx) {
-					webhookServer.MarkCacheSynced()
-				} else {
-					logger.Error("informer cache failed to sync; webhook /readyz will stay 503")
-				}
-			}()
-
-			// Log when manager is elected as leader
-			go func() {
-				<-mgr.Elected()
-				logger.Info("Controller manager elected as leader and ready to process resources")
-			}()
-
-			// Start the manager synchronously. This blocks until the context is cancelled
-			// (SIGTERM/SIGINT) or the manager fails (e.g. leader election lost).
-			// When it returns, the process exits — no zombie state possible.
-			logger.Info("Starting controller manager")
-			if err := mgr.Start(ctx); err != nil {
-				logger.Error("controller manager failed", zap.Error(err))
-				fatal()
-			}
+			runManager()
 		},
 	}
-
-	// Add version command
 	rootCmd.AddCommand(version.NewVersionCmd())
-
-	// Setup flags
 	config.SetupFlags(rootCmd)
+	return rootCmd
+}
 
-	// Execute the root command
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+// runManager wires and starts the controller manager and webhook server,
+// blocking until the context is cancelled (SIGTERM/SIGINT) or the manager fails.
+// nolint:gocyclo
+func runManager() {
+	// Initialize configuration
+	cfg := config.InitConfig()
+
+	// Set up logging
+	pkglogger.Initialize(cfg)
+	logger := pkglogger.L()
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			logger.Error("Failed to sync logger", zap.Error(err))
+		}
+	}()
+	// fatal exits 1 after flushing the logger so the last error line is
+	// guaranteed to surface even when os.Exit short-circuits the defers.
+	fatal := func() {
+		_ = logger.Sync()
 		os.Exit(1)
+	}
+
+	// Configure controller-runtime logger to use zap for consistent JSON formatting
+	ctrl.SetLogger(zapctrl.New(zapctrl.UseDevMode(false), zapctrl.JSONEncoder()))
+
+	// Use controller-runtime's signal handler — cancels context on SIGTERM/SIGINT
+	ctx := ctrl.SetupSignalHandler()
+
+	// Initialize scheme
+	scheme := manager.InitScheme()
+
+	// Create controller manager
+	mgr, err := manager.SetupManager(cfg, scheme)
+	if err != nil {
+		logger.Error("unable to start manager", zap.Error(err))
+		fatal()
+	}
+
+	// Set up controllers
+	if err := manager.SetupControllers(ctx, mgr, cfg, logger); err != nil {
+		logger.Error("unable to set up controllers", zap.Error(err))
+		fatal()
+	}
+
+	// Create kubernetes clientset for webhook server
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		logger.Error("unable to create kubernetes clientset", zap.Error(err))
+		fatal()
+	}
+
+	// Set up Gin webhook server with manager's client for CRQ operations
+	webhookServer, webhookCertWatcher := webhook.SetupGinWebhookServer(cfg, clientset, mgr.GetClient(), logger)
+
+	// Start webhook server and cert watcher in background goroutines.
+	// They respect context cancellation via <-ctx.Done() for graceful shutdown.
+	go func() {
+		if err := webhookServer.Start(ctx); err != nil {
+			logger.Error("webhook server failed", zap.Error(err))
+		}
+	}()
+
+	if webhookCertWatcher != nil {
+		go func() {
+			if err := webhookCertWatcher.Start(ctx); err != nil {
+				logger.Error("webhook certificate watcher failed", zap.Error(err))
+			}
+		}()
+	}
+
+	// Flip the webhook's cache-sync readiness gate once the manager's
+	// informer cache has finished initial sync. Until then /readyz
+	// returns 503 so the apiserver does not route admission traffic to
+	// a webhook whose CRQ lookups would hit a cold cache.
+	go func() {
+		if mgr.GetCache().WaitForCacheSync(ctx) {
+			webhookServer.MarkCacheSynced()
+		} else {
+			logger.Error("informer cache failed to sync; webhook /readyz will stay 503")
+		}
+	}()
+
+	// Log when manager is elected as leader
+	go func() {
+		<-mgr.Elected()
+		logger.Info("Controller manager elected as leader and ready to process resources")
+	}()
+
+	// Start the manager synchronously. This blocks until the context is cancelled
+	// (SIGTERM/SIGINT) or the manager fails (e.g. leader election lost).
+	// When it returns, the process exits — no zombie state possible.
+	logger.Info("Starting controller manager")
+	if err := mgr.Start(ctx); err != nil {
+		logger.Error("controller manager failed", zap.Error(err))
+		fatal()
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestNewRootCommand(t *testing.T) {
+	cmd := newRootCommand()
+
+	if cmd.Use != "controller-manager" {
+		t.Errorf("unexpected Use %q", cmd.Use)
+	}
+
+	hasVersion := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "version" {
+			hasVersion = true
+		}
+	}
+	if !hasVersion {
+		t.Error("version subcommand not registered")
+	}
+
+	for _, flag := range []string{"leader-elect", "log-level", "webhook-port", "events-enable"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("flag %q not registered", flag)
+		}
+	}
+}
+
+// Executing the version subcommand exercises the command wiring without starting
+// the manager (which would require a real cluster).
+func TestRootCommandRunsVersionSubcommand(t *testing.T) {
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"version"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("executing version subcommand: %v", err)
+	}
+}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,18 @@
+package version
+
+import "testing"
+
+func TestNewVersionCmd(t *testing.T) {
+	cmd := NewVersionCmd()
+	if cmd.Use != "version" {
+		t.Errorf("unexpected Use %q", cmd.Use)
+	}
+	if cmd.Run == nil {
+		t.Error("version command has no Run function")
+	}
+}
+
+func TestPrintInfo(t *testing.T) {
+	// Smoke test: PrintInfo writes build info to stdout and must not panic.
+	PrintInfo()
+}

--- a/internal/controller/clusterresourcequota_controller.go
+++ b/internal/controller/clusterresourcequota_controller.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -714,7 +715,8 @@ func (r *ClusterResourceQuotaReconciler) installWatches(mgr ctrl.Manager) error 
 	}
 
 	b := ctrl.NewControllerManagedBy(mgr).
-		For(&quotav1alpha1.ClusterResourceQuota{})
+		For(&quotav1alpha1.ClusterResourceQuota{}).
+		WithOptions(ctrlcontroller.Options{MaxConcurrentReconciles: 5})
 	for _, w := range watched {
 		b = b.Watches(
 			w.obj,

--- a/test/e2e/clusterresourcequota_webhook_test.go
+++ b/test/e2e/clusterresourcequota_webhook_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
@@ -55,7 +53,15 @@ var _ = Describe("ClusterResourceQuota Webhook", func() {
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 				})
 			Expect(err).ToNot(HaveOccurred())
-			time.Sleep(2 * time.Second) // Ensure CRQ is updated by reconciliation
+
+			// Wait for the controller to reconcile the CRQ at least once.
+			Eventually(func() bool {
+				fresh := &quotav1alpha1.ClusterResourceQuota{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: crqName}, fresh); err != nil {
+					return false
+				}
+				return fresh.Status.Total.Used != nil
+			}, Timeout, Interval).Should(BeTrue())
 
 			By("Updating the ClusterResourceQuota spec")
 			err = testutils.UpdateClusterResourceQuotaSpec(
@@ -106,7 +112,7 @@ var _ = Describe("ClusterResourceQuota Webhook", func() {
 					}
 				}
 				return false
-			}, time.Second*30, time.Second*1).Should(BeTrue(), "First CRQ should have the namespace in its status")
+			}, Timeout, Interval).Should(BeTrue(), "First CRQ should have the namespace in its status")
 
 			By("Attempting to create a second ClusterResourceQuota with overlapping namespace selector")
 			_, err = testutils.CreateClusterResourceQuota(ctx, k8sClient, "crq2-"+suffix, &metav1.LabelSelector{

--- a/test/e2e/controller_reconcile_test.go
+++ b/test/e2e/controller_reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,9 +21,20 @@ import (
 )
 
 const (
-	Timeout  = time.Second * 30
-	Interval = time.Second * 5
+	Timeout  = time.Second * 60
+	Interval = time.Second * 1
 )
+
+// waitForJobTerminal blocks until the job records a terminal pod (failed or succeeded).
+func waitForJobTerminal(job *batchv1.Job) {
+	GinkgoHelper()
+	Eventually(func() bool {
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: job.Name, Namespace: job.Namespace}, job); err != nil {
+			return false
+		}
+		return job.Status.Failed > 0 || job.Status.Succeeded > 0
+	}, Timeout, Interval).Should(BeTrue())
+}
 
 var _ = Describe("ClusterResourceQuota Controller E2E Tests", func() {
 	var (
@@ -353,8 +365,7 @@ var _ = Describe("ClusterResourceQuota Controller E2E Tests", func() {
 					_ = k8sClient.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
 				})
 
-				// Wait longer for job to fail and become terminal
-				time.Sleep(5 * time.Second)
+				waitForJobTerminal(job)
 
 				// Terminal pods should not affect quota usage
 				Eventually(func() error {
@@ -380,8 +391,7 @@ var _ = Describe("ClusterResourceQuota Controller E2E Tests", func() {
 					_ = k8sClient.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
 				})
 
-				// Wait longer for job to succeed and become terminal
-				time.Sleep(5 * time.Second)
+				waitForJobTerminal(job)
 
 				// Terminal pods should not affect quota usage
 				Eventually(func() error {
@@ -634,8 +644,8 @@ var _ = Describe("ClusterResourceQuota Controller E2E Tests", func() {
 				})
 
 				By("Waiting for jobs to reach terminal state")
-				// Give more time for jobs to fail/succeed and become terminal
-				time.Sleep(8 * time.Second)
+				waitForJobTerminal(failedJob)
+				waitForJobTerminal(succeededJob)
 
 				By("Verifying only active pods are counted in resource usage")
 				// Expected: webPod (100m CPU, 128Mi memory) + dbPod (500m CPU, 1Gi memory) = 600m CPU, 1152Mi memory

--- a/test/e2e/service_webhook_test.go
+++ b/test/e2e/service_webhook_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
@@ -49,7 +47,7 @@ var _ = Describe("Service Quota Webhook", func() {
 
 		// Wait for CRQ status to include the test namespace before proceeding
 		By("Waiting for CRQ status to include the test namespace")
-		err = testutils.WaitForCRQStatus(ctx, k8sClient, testCRQName, []string{testNamespace}, 10*time.Second, 1*time.Second)
+		err = testutils.WaitForCRQStatus(ctx, k8sClient, testCRQName, []string{testNamespace}, Timeout, Interval)
 		Expect(err).NotTo(
 			HaveOccurred(),
 			"CRQ status did not include the test namespace in time; check CRQ selector and namespace labels",

--- a/test/e2e/storage_resources_test.go
+++ b/test/e2e/storage_resources_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Storage Resources E2E", func() {
 					return usage.Equal(expectedUsage)
 				}
 				return false
-			}, "30s", "1s").Should(BeTrue())
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 
@@ -150,7 +150,7 @@ var _ = Describe("Storage Resources E2E", func() {
 					return usage.Equal(expectedUsage)
 				}
 				return false
-			}, "30s", "1s").Should(BeTrue())
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 
@@ -247,7 +247,7 @@ var _ = Describe("Storage Resources E2E", func() {
 				expectedEphemeral := resource.MustParse("500Mi")
 
 				return storageUsage.Equal(expectedStorage) && ephemeralUsage.Equal(expectedEphemeral)
-			}, "30s", "1s").Should(BeTrue())
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 })

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -298,16 +298,21 @@ func WaitForCRQResourceUsage(
 	expected resource.Quantity,
 ) error {
 	const (
-		timeout  = 30 * time.Second
-		interval = 250 * time.Millisecond
+		timeout     = 60 * time.Second
+		interval    = 250 * time.Millisecond
+		callTimeout = 5 * time.Second
 	)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return wait.PollUntilContextTimeout(ctxWithTimeout, interval, timeout, true,
-		func(ctx context.Context) (bool, error) {
+		func(_ context.Context) (bool, error) {
 			crq := &quotav1alpha1.ClusterResourceQuota{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Name: crqName}, crq); err != nil {
-				return false, err
+			// Use a short per-call context so a slow API call doesn't consume
+			// the entire polling budget. Treat transient errors as not-yet-ready.
+			getCtx, getCancel := context.WithTimeout(ctx, callTimeout)
+			defer getCancel()
+			if err := k8sClient.Get(getCtx, client.ObjectKey{Name: crqName}, crq); err != nil {
+				return false, nil
 			}
 			used, ok := crq.Status.Total.Used[resourceName]
 			if !ok {


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

<!--
Provide a detailed description of your changes:
- What problem does this solve?
- How did you solve it?
- What are the key changes?
- Why did you choose this approach?
-->
This pull request refactors the main command structure for the controller manager, improves testability, and enhances the reliability and speed of end-to-end (E2E) tests. The changes include extracting command wiring logic for easier testing, adding new unit tests, tuning E2E test timeouts and polling, and improving controller concurrency. The most important changes are grouped below.

**Command Structure Refactor and Testability:**

* Extracted the root command construction into a new `newRootCommand` function in `cmd/main.go`, making the command wiring testable and separating command setup from execution. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L24-R50) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L124-L137)
* Added a new unit test file `cmd/main_test.go` to verify that the root command is constructed correctly, including flags and subcommands.
* Added a new unit test file `cmd/version/version_test.go` to test the version subcommand and its output.

**Controller and Reconciliation Improvements:**

* Increased the controller's concurrency by setting `MaxConcurrentReconciles` to 5 in the `ClusterResourceQuota` controller, potentially improving throughput.
* Updated import to use the correct controller-runtime controller package alias.

**E2E Test Reliability and Speed:**

* Replaced arbitrary `time.Sleep` calls in E2E tests with polling-based waits (`Eventually`), making tests more reliable and less flaky. [[1]](diffhunk://#diff-c4ad15dcf33db1e74da743e60606def550d0aaf12ba6767771ca001373dfba3eL58-R64) [[2]](diffhunk://#diff-db5c7a057ebc64c40bd9ef47a7a2502301b2b2d4193b0b0b909ae20fccba7e47L356-R368) [[3]](diffhunk://#diff-db5c7a057ebc64c40bd9ef47a7a2502301b2b2d4193b0b0b909ae20fccba7e47L383-R394) [[4]](diffhunk://#diff-db5c7a057ebc64c40bd9ef47a7a2502301b2b2d4193b0b0b909ae20fccba7e47L637-R648)
* Increased default E2E test timeouts and decreased polling intervals for faster feedback and higher reliability. [[1]](diffhunk://#diff-db5c7a057ebc64c40bd9ef47a7a2502301b2b2d4193b0b0b909ae20fccba7e47L23-R38) [[2]](diffhunk://#diff-f9f1a5591b507d1d6065be97ebf378790d780c0e50716816948aad7fe19a05c1L85-R85) [[3]](diffhunk://#diff-f9f1a5591b507d1d6065be97ebf378790d780c0e50716816948aad7fe19a05c1L153-R153) [[4]](diffhunk://#diff-f9f1a5591b507d1d6065be97ebf378790d780c0e50716816948aad7fe19a05c1L250-R250)
* Added a helper function `waitForJobTerminal` to block until Kubernetes jobs reach a terminal state, improving test determinism.

**Test Utility Improvements:**

* Updated `WaitForCRQResourceUsage` in `test/utils/helpers.go` to use a per-call timeout for API calls, preventing a slow call from consuming the entire polling budget and making error handling more robust.

**Minor Cleanups:**

* Removed unused imports and updated test code to use new timeout/interval constants. [[1]](diffhunk://#diff-c4ad15dcf33db1e74da743e60606def550d0aaf12ba6767771ca001373dfba3eL4-L5) [[2]](diffhunk://#diff-f84ccc4aaf474b25eb8cde4624f4e52608ccca5afafaf8e3706252eda55db99dL4-L5) [[3]](diffhunk://#diff-f84ccc4aaf474b25eb8cde4624f4e52608ccca5afafaf8e3706252eda55db99dL52-R50) [[4]](diffhunk://#diff-db5c7a057ebc64c40bd9ef47a7a2502301b2b2d4193b0b0b909ae20fccba7e47R15)

These changes collectively improve the maintainability, test coverage, and reliability of both the controller and its tests.

## 📚 Documentation

<!--
Describe documentation changes:
- Updated README
- Added new docs
- Updated API documentation

-->

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [ ] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [ ] 🔧 Ran pre-commit hooks to validate changes:
  - [ ] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **📝 Note:** Chart and app versioning are manual. See CONTRIBUTING.md for details on how to release.
> **🐙 Note:** For Helm chart installation, use GHCR as an OCI registry. See README for instructions.
