### PR TITLE
chore(release): bump app and chart to 0.5.0

### DIFF
--- a/charts/pac-quota-controller/Chart.yaml
+++ b/charts/pac-quota-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pac-quota-controller
 description: A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 type: application
-version: 0.4.5
-appVersion: "0.4.4"
+version: 0.5.0
+appVersion: "0.5.0"
 maintainers:
   - name: PowerHome
     url: https://github.com/powerhome

--- a/charts/pac-quota-controller/README.md
+++ b/charts/pac-quota-controller/README.md
@@ -1,6 +1,6 @@
 # pac-quota-controller
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.4](https://img.shields.io/badge/AppVersion-0.4.4-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 
@@ -71,7 +71,7 @@ spec:
 This chart can use container images from GitHub Container Registry:
 
 ```console
-ghcr.io/powerhome/pac-quota-controller:0.4.4
+ghcr.io/powerhome/pac-quota-controller:0.5.0
 ```
 
 You can configure which registry to use by modifying the `controllerManager.container.image.repository` value.


### PR DESCRIPTION
## 📖 Description

Bump app and chart versions to 0.5.0.

- `version`: 0.4.5 → 0.5.0
- `appVersion`: 0.4.4 → 0.5.0
- Regenerated chart README via `make helm-docs`

### Versioning & Release

- [x] 📊 Bumped chart `version`
- [x] 🏷️ Bumped `appVersion`