### PR TITLE
fix: enforce ephemeral-storage requests and limits quotas

### DIFF
--- a/internal/controller/clusterresourcequota_controller.go
+++ b/internal/controller/clusterresourcequota_controller.go
@@ -606,7 +606,8 @@ func (r *ClusterResourceQuotaReconciler) isComputeResource(resourceName corev1.R
 
 	// Standard compute resources (already handled in switch above, but included for completeness)
 	switch resourceName {
-	case corev1.ResourceRequestsCPU, corev1.ResourceRequestsMemory, corev1.ResourceLimitsCPU, corev1.ResourceLimitsMemory, corev1.ResourceRequestsEphemeralStorage:
+	case corev1.ResourceRequestsCPU, corev1.ResourceRequestsMemory, corev1.ResourceLimitsCPU, corev1.ResourceLimitsMemory,
+		corev1.ResourceRequestsEphemeralStorage, corev1.ResourceLimitsEphemeralStorage:
 		return true
 	}
 

--- a/internal/controller/clusterresourcequota_controller_test.go
+++ b/internal/controller/clusterresourcequota_controller_test.go
@@ -1125,6 +1125,28 @@ var _ = Describe("ClusterResourceQuota Controller", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(got.String()).To(Equal("2"))
 		})
+
+		It("computes ephemeral-storage limits from the in-memory pod slice", func() {
+			reconciler := &ClusterResourceQuotaReconciler{}
+			pods := []corev1.Pod{
+				{
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+							},
+						},
+					}}},
+				},
+			}
+
+			got, err := reconciler.computeNamespaceResourceUsage(
+				ctx, "ns-a", corev1.ResourceLimitsEphemeralStorage, pods, nil, nil, nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Equal(resource.MustParse("2Gi"))).To(BeTrue())
+		})
 	})
 
 	Context("Service Usage From Prefetched Services", func() {
@@ -1202,6 +1224,14 @@ var _ = Describe("ClusterResourceQuota Controller", Ordered, func() {
 				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("4"),
 			})
 			Expect(kinds.pods).To(BeTrue())
+		})
+
+		It("marks limits.ephemeral-storage as needing pods", func() {
+			kinds := r.classifyKindsNeeded(quotav1alpha1.ResourceList{
+				corev1.ResourceLimitsEphemeralStorage: resource.MustParse("2Gi"),
+			})
+			Expect(kinds.pods).To(BeTrue())
+			Expect(kinds.pvcs).To(BeFalse())
 		})
 	})
 

--- a/pkg/kubernetes/pod/pod.go
+++ b/pkg/kubernetes/pod/pod.go
@@ -122,6 +122,10 @@ func getContainerResourceUsage(container corev1.Container, resourceName corev1.R
 		if ephemeralStorage, ok := container.Resources.Requests[corev1.ResourceEphemeralStorage]; ok {
 			return ephemeralStorage
 		}
+	case corev1.ResourceLimitsEphemeralStorage:
+		if ephemeralStorage, ok := container.Resources.Limits[corev1.ResourceEphemeralStorage]; ok {
+			return ephemeralStorage
+		}
 	case corev1.ResourceLimitsCPU:
 		if cpu, ok := container.Resources.Limits[corev1.ResourceCPU]; ok {
 			return cpu

--- a/pkg/kubernetes/pod/pod_test.go
+++ b/pkg/kubernetes/pod/pod_test.go
@@ -348,6 +348,24 @@ var _ = Describe("Pod", func() {
 			Expect(result.Equal(resource.MustParse("1Gi"))).To(BeTrue())
 		})
 
+		It("should handle ephemeral storage limits", func() {
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			}
+			result := CalculatePodUsage(pod, corev1.ResourceLimitsEphemeralStorage)
+			Expect(result.Equal(resource.MustParse("2Gi"))).To(BeTrue())
+		})
+
 		It("should handle CPU limits", func() {
 			pod := &corev1.Pod{
 				Spec: corev1.PodSpec{

--- a/pkg/webhook/v1alpha1/pod_webhook.go
+++ b/pkg/webhook/v1alpha1/pod_webhook.go
@@ -103,6 +103,8 @@ func (h *PodWebhook) validateOperation(
 		{usage.ResourceRequestsMemory, "memory requests"},
 		{usage.ResourceLimitsCPU, "CPU limits"},
 		{usage.ResourceLimitsMemory, "memory limits"},
+		{usage.ResourceRequestsEphemeralStorage, "ephemeral-storage requests"},
+		{usage.ResourceLimitsEphemeralStorage, "ephemeral-storage limits"},
 	}
 
 	for _, c := range computeResources {

--- a/pkg/webhook/v1alpha1/pod_webhook_test.go
+++ b/pkg/webhook/v1alpha1/pod_webhook_test.go
@@ -70,6 +70,32 @@ func makePod(name, cpuReq, memReq, cpuLim, memLim string) *corev1.Pod {
 	}
 }
 
+func makeEphemeralPod(name, ephemeralReq, ephemeralLim string) *corev1.Pod {
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+	if ephemeralReq != "" {
+		requests[corev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralReq)
+	}
+	if ephemeralLim != "" {
+		limits[corev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralLim)
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: podWebhookTestNamespace},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "c",
+					Image: "busybox",
+					Resources: corev1.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+}
+
 var _ = Describe("PodWebhook", func() {
 	const (
 		nsName  = podWebhookTestNamespace
@@ -210,6 +236,68 @@ var _ = Describe("PodWebhook", func() {
 			resp := sendWebhookRequest(engine, newPodReview("5", pod))
 			Expect(resp.Response.Allowed).To(BeFalse())
 			Expect(resp.Response.Result.Message).To(ContainSubstring("memory limits"))
+		})
+
+		It("denies when ephemeral-storage requests would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsEphemeralStorage: quantity("2Gi"),
+					usage.ResourcePods:                     quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceRequestsEphemeralStorage: quantity("2Gi"),
+					usage.ResourcePods:                     quantity("0"),
+				},
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			pod := makeEphemeralPod("p1", "1Gi", "")
+			resp := sendWebhookRequest(engine, newPodReview("6", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("ephemeral-storage requests"))
+		})
+
+		It("denies when ephemeral-storage limits would exceed the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsEphemeralStorage: quantity("2Gi"),
+					usage.ResourcePods:                   quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsEphemeralStorage: quantity("2Gi"),
+					usage.ResourcePods:                   quantity("0"),
+				},
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			pod := makeEphemeralPod("p1", "", "1Gi")
+			resp := sendWebhookRequest(engine, newPodReview("7", pod))
+			Expect(resp.Response.Allowed).To(BeFalse())
+			Expect(resp.Response.Result.Message).To(ContainSubstring("ephemeral-storage limits"))
+		})
+
+		It("admits a pod when ephemeral-storage stays under the quota", func() {
+			ns := makeNamespace(nsName, labels)
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsEphemeralStorage: quantity("4Gi"),
+					usage.ResourcePods:                   quantity("10"),
+				},
+				quotav1alpha1.ResourceList{
+					usage.ResourceLimitsEphemeralStorage: quantity("1Gi"),
+					usage.ResourcePods:                   quantity("1"),
+				},
+			)
+			h := NewPodWebhook(newTestCRQClient(ns, crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			pod := makeEphemeralPod("p1", "", "2Gi")
+			resp := sendWebhookRequest(engine, newPodReview("8", pod))
+			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 
 		It("denies when the pod count would exceed the quota even with no resource requests", func() {

--- a/test/e2e/storage_resources_test.go
+++ b/test/e2e/storage_resources_test.go
@@ -87,12 +87,12 @@ var _ = Describe("Storage Resources E2E", func() {
 	})
 
 	Context("Ephemeral Storage Usage", func() {
-		It("should track ephemeral storage usage from Pods", func() {
-			By("Creating a namespace with the appropriate label")
+		// Asserts a Pod's ephemeral-storage usage aggregates into the CRQ status under quotaRes.
+		trackEphemeralStorage := func(label string, quotaRes corev1.ResourceName, podResources corev1.ResourceRequirements) {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "ephemeral-test-" + suffix,
-					Labels: map[string]string{"ephemeral-quota": "enabled-" + suffix},
+					Name:   label + "-test-" + suffix,
+					Labels: map[string]string{label + "-quota": "enabled-" + suffix},
 				},
 			}
 			Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
@@ -100,36 +100,25 @@ var _ = Describe("Storage Resources E2E", func() {
 				Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
 			}()
 
-			By("Creating a ClusterResourceQuota with ephemeral storage limits")
 			crq, err := testutils.CreateClusterResourceQuota(ctx, k8sClient, crqName, &metav1.LabelSelector{
-				MatchLabels: map[string]string{"ephemeral-quota": "enabled-" + suffix},
+				MatchLabels: map[string]string{label + "-quota": "enabled-" + suffix},
 			}, quotav1alpha1.ResourceList{
-				corev1.ResourceRequestsEphemeralStorage: resource.MustParse("2Gi"),
+				quotaRes: resource.MustParse("2Gi"),
 			})
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				Expect(k8sClient.Delete(ctx, crq)).To(Succeed())
 			}()
 
-			By("Creating a Pod with ephemeral storage request")
 			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod-" + suffix,
-					Namespace: namespace.Name,
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod-" + label + "-" + suffix, Namespace: namespace.Name},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "test-container",
-							Image: "busybox:latest",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-								},
-							},
-							Command: []string{"sleep", "3600"},
-						},
-					},
+					Containers: []corev1.Container{{
+						Name:      "test-container",
+						Image:     "busybox:latest",
+						Resources: podResources,
+						Command:   []string{"sleep", "3600"},
+					}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
@@ -137,20 +126,27 @@ var _ = Describe("Storage Resources E2E", func() {
 				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
 			}()
 
-			By("Waiting for the CRQ status to be updated with ephemeral storage usage")
+			By("Waiting for the CRQ status to aggregate the ephemeral storage usage")
 			Eventually(func() bool {
 				latestCRQ := &quotav1alpha1.ClusterResourceQuota{}
 				if err := k8sClient.Get(ctx, types.NamespacedName{Name: crqName}, latestCRQ); err != nil {
 					return false
 				}
-
-				// Check if ephemeral storage usage is reported
-				if usage, exists := latestCRQ.Status.Total.Used[corev1.ResourceRequestsEphemeralStorage]; exists {
-					expectedUsage := resource.MustParse("1Gi")
-					return usage.Equal(expectedUsage)
-				}
-				return false
+				usage, exists := latestCRQ.Status.Total.Used[quotaRes]
+				return exists && usage.Equal(resource.MustParse("1Gi"))
 			}, Timeout, Interval).Should(BeTrue())
+		}
+
+		It("should track ephemeral storage requests from Pods", func() {
+			trackEphemeralStorage("ephemeral", corev1.ResourceRequestsEphemeralStorage, corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("1Gi")},
+			})
+		})
+
+		It("should track ephemeral storage limits from Pods", func() {
+			trackEphemeralStorage("ephemeral-limits", corev1.ResourceLimitsEphemeralStorage, corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("1Gi")},
+			})
 		})
 	})
 


### PR DESCRIPTION
## 📖 Description

This pull request adds support for tracking and enforcing ephemeral-storage *limits* (in addition to requests) in ClusterResourceQuota and Pod admission logic. The changes ensure that both ephemeral-storage requests and limits are properly accounted for, validated, and tested throughout the codebase.

**Ephemeral-storage limits support:**

* Updated the core logic to recognize and handle `ResourceLimitsEphemeralStorage` as a compute resource in `ClusterResourceQuotaReconciler`, ensuring it is tracked and enforced like other compute resources.
* Extended resource usage calculation to read ephemeral-storage limits from pod containers in `getContainerResourceUsage`, enabling accurate quota enforcement.

**Testing and validation:**

* Added/expanded unit and integration tests to verify that ephemeral-storage limits are computed, classified, and enforced throughout the controller and webhook logic (`clusterresourcequota_controller_test.go`, `pod.go`, `pod_test.go`, `pod_webhook_test.go`). [[1]](diffhunk://#diff-8102fc58ef1db8d8466bb4a33e4c37d5fecf3d048788b132eff0ab4724d5bcfcR1128-R1149) [[2]](diffhunk://#diff-8102fc58ef1db8d8466bb4a33e4c37d5fecf3d048788b132eff0ab4724d5bcfcR1228-R1235) [[3]](diffhunk://#diff-222c69a3e8d4ac41ea0ccdd983cd09530ebfe74389cac8e0c9b789e8d05b8cb2R351-R368) [[4]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64R73-R98) [[5]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64R241-R302)
* Updated the pod admission webhook to validate both ephemeral-storage requests and limits, denying pods that would exceed the quota, and added corresponding tests. [[1]](diffhunk://#diff-898ec9e03cd0ea5b28303ea3976ab16551d65a34a2ad49fd6d21275192d30e51R106-R107) [[2]](diffhunk://#diff-63ff1ec178af775a282c4b846dd954fa3f844b5bbc1b0b11a7f4fc5f58fccb64R241-R302)

**End-to-end coverage:**

* Refactored and extended e2e tests to assert that both ephemeral-storage requests and limits are aggregated and tracked in ClusterResourceQuota status.

### Testing & Validation

- [x] ✅ Added unit, webhook, and e2e tests
- [x] 🔧 `make test` and `make test-e2e` pass