### PR TITLE
chore(release): bump appVersion to 0.5.1

### DIFF
--- a/charts/pac-quota-controller/Chart.yaml
+++ b/charts/pac-quota-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: pac-quota-controller
 description: A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 type: application
 version: 0.5.0
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 maintainers:
   - name: PowerHome
     url: https://github.com/powerhome

--- a/charts/pac-quota-controller/README.md
+++ b/charts/pac-quota-controller/README.md
@@ -1,6 +1,6 @@
 # pac-quota-controller
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
 
 A Helm chart for PAC Quota Controller - Managing cluster resource quotas across namespaces
 
@@ -71,7 +71,7 @@ spec:
 This chart can use container images from GitHub Container Registry:
 
 ```console
-ghcr.io/powerhome/pac-quota-controller:0.5.0
+ghcr.io/powerhome/pac-quota-controller:0.5.1
 ```
 
 You can configure which registry to use by modifying the `controllerManager.container.image.repository` value.


### PR DESCRIPTION
## 📖 Description

App-only release. Ships the ephemeral-storage quota fix (#122).

- `appVersion`: 0.5.0 → 0.5.1
- Chart `version` unchanged (no chart changes)

### Versioning & Release

- [x] 🏷️ Bumped `appVersion`
- [ ] 📊 Chart `version` (n/a — no chart change)