### PR TITLE
feat(api): quota scope CRD schema and CEL validation

### DIFF
--- a/api/v1alpha1/clusterresourcequota_types.go
+++ b/api/v1alpha1/clusterresourcequota_types.go
@@ -36,10 +36,20 @@ type ClusterResourceQuotaSpec struct {
 	// 'pods': '10' (Pod count)
 	// 'services': '5' (Service count)
 	// 'services.loadbalancers': '2' (Service type=LoadBalancer count)
-	// 'ingresses': '3' (Ingress count)
+	// 'services.nodeports': '3' (Service type=NodePort count)
 	// 'configmaps': '20' (ConfigMap count)
+	// 'secrets': '15' (Secret count)
+	// 'persistentvolumeclaims': '8' (PVC count)
+	// 'replicationcontrollers': '4' (ReplicationController count)
+	// 'deployments.apps': '6' (Deployment count)
+	// 'statefulsets.apps': '2' (StatefulSet count)
+	// 'daemonsets.apps': '2' (DaemonSet count)
+	// 'jobs.batch': '5' (Job count)
+	// 'cronjobs.batch': '3' (CronJob count)
+	// 'horizontalpodautoscalers.autoscaling': '2' (HPA count)
+	// 'ingresses.networking.k8s.io': '3' (Ingress count)
+	//
 	// ...and so on for all supported native and extended resource types.
-	// See documentation for the full list of supported resource keys.
 	// +optional
 	Hard ResourceList `json:"hard,omitempty"`
 
@@ -49,23 +59,32 @@ type ClusterResourceQuotaSpec struct {
 	// +required
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector"`
 
-	// ScopeSelector is also a collection of filters like scopes that must match each object tracked by a quota
-	// but expressed using ScopeSelectorOperator in combination with possible values.
-	// For example, to select objects where any container has a resource request that exceeds 100m CPU,
-	// you would use: scopeSelector.matchExpressions: [{operator: In, scopeName: PriorityClass, values: ['high']}]
+	// ScopeSelector is a collection of scope filters expressed using ScopeSelectorOperator
+	// in combination with possible values, ANDed with Scopes. Scopes filter pods only:
+	// non-pod resources in Hard are rejected at admission when any scope is set.
+	// Example: scopeSelector.matchExpressions: [{operator: In, scopeName: PriorityClass, values: ['high']}]
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.matchExpressions.all(m, m.scopeName in ['Terminating','NotTerminating','BestEffort','NotBestEffort','PriorityClass','CrossNamespacePodAffinity'])",message="scopeSelector: invalid scope name"
+	// +kubebuilder:validation:XValidation:rule="self.matchExpressions.all(m, m.operator in ['In','NotIn','Exists','DoesNotExist'])",message="scopeSelector: invalid operator"
+	// +kubebuilder:validation:XValidation:rule="self.matchExpressions.all(m, m.scopeName == 'PriorityClass' || m.operator == 'Exists')",message="scopeSelector: only the PriorityClass scope supports operators other than Exists"
+	// +kubebuilder:validation:XValidation:rule="self.matchExpressions.all(m, (m.operator == 'In' || m.operator == 'NotIn') == (size(m.values) > 0))",message="scopeSelector: values must be non-empty for In/NotIn and empty for Exists/DoesNotExist"
+	// +kubebuilder:validation:XValidation:rule="!(self.matchExpressions.exists(m, m.scopeName == 'BestEffort') && self.matchExpressions.exists(m, m.scopeName == 'NotBestEffort'))",message="scopeSelector: BestEffort and NotBestEffort scopes are mutually exclusive"
+	// +kubebuilder:validation:XValidation:rule="!(self.matchExpressions.exists(m, m.scopeName == 'Terminating') && self.matchExpressions.exists(m, m.scopeName == 'NotTerminating'))",message="scopeSelector: Terminating and NotTerminating scopes are mutually exclusive"
 	ScopeSelector *corev1.ScopeSelector `json:"scopeSelector,omitempty"`
 
-	// A collection of filters that must match each object tracked by a quota.
-	// If not specified, the quota matches all objects.
+	// Scopes is a collection of filters that must all match each pod tracked by the quota.
+	// If not specified, the quota matches all pods. Scopes filter pods only.
 	// Available scopes are:
 	// - Terminating: match pods where spec.activeDeadlineSeconds >= 0
 	// - NotTerminating: match pods where spec.activeDeadlineSeconds is nil
 	// - BestEffort: match pods that have best effort quality of service
 	// - NotBestEffort: match pods that do not have best effort quality of service
-	// - PriorityClass: match pods that have the specified priority class
-	// - CrossNamespacePodAffinity: match pods that have cross-namespace pod affinity terms
+	// - PriorityClass: match pods that have any priority class set
+	// - CrossNamespacePodAffinity: match pods with cross-namespace pod (anti)affinity terms
 	// +optional
+	// +kubebuilder:validation:items:Enum=Terminating;NotTerminating;BestEffort;NotBestEffort;PriorityClass;CrossNamespacePodAffinity
+	// +kubebuilder:validation:XValidation:rule="!('BestEffort' in self && 'NotBestEffort' in self)",message="BestEffort and NotBestEffort scopes are mutually exclusive"
+	// +kubebuilder:validation:XValidation:rule="!('Terminating' in self && 'NotTerminating' in self)",message="Terminating and NotTerminating scopes are mutually exclusive"
 	Scopes []corev1.ResourceQuotaScope `json:"scopes,omitempty"`
 }
 
@@ -101,6 +120,25 @@ func (crqs *ClusterResourceQuotaStatus) GetNamespaces() []string {
 // ClusterResourceQuota is the Schema for the clusterresourcequotas API.
 // It extends the standard Kubernetes ResourceQuota by allowing it to be applied across multiple
 // namespaces that match a label selector.
+//
+// Supported object count resources (for use in the 'hard' and 'used' fields):
+//   - pods
+//   - services
+//   - services.loadbalancers
+//   - services.nodeports
+//   - configmaps
+//   - secrets
+//   - persistentvolumeclaims
+//   - replicationcontrollers
+//   - deployments.apps
+//   - statefulsets.apps
+//   - daemonsets.apps
+//   - jobs.batch
+//   - cronjobs.batch
+//   - horizontalpodautoscalers.autoscaling
+//   - ingresses.networking.k8s.io
+//
+// You may specify quotas for any of these resources. See the Helm chart documentation for details and examples.
 type ClusterResourceQuota struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/charts/pac-quota-controller/crds/quota.powerapp.cloud_clusterresourcequotas.yaml
+++ b/charts/pac-quota-controller/crds/quota.powerapp.cloud_clusterresourcequotas.yaml
@@ -31,6 +31,25 @@ spec:
           ClusterResourceQuota is the Schema for the clusterresourcequotas API.
           It extends the standard Kubernetes ResourceQuota by allowing it to be applied across multiple
           namespaces that match a label selector.
+
+          Supported object count resources (for use in the 'hard' and 'used' fields):
+            - pods
+            - services
+            - services.loadbalancers
+            - services.nodeports
+            - configmaps
+            - secrets
+            - persistentvolumeclaims
+            - replicationcontrollers
+            - deployments.apps
+            - statefulsets.apps
+            - daemonsets.apps
+            - jobs.batch
+            - cronjobs.batch
+            - horizontalpodautoscalers.autoscaling
+            - ingresses.networking.k8s.io
+
+          You may specify quotas for any of these resources. See the Helm chart documentation for details and examples.
         properties:
           apiVersion:
             description: |-
@@ -65,10 +84,20 @@ spec:
                   'pods': '10' (Pod count)
                   'services': '5' (Service count)
                   'services.loadbalancers': '2' (Service type=LoadBalancer count)
-                  'ingresses': '3' (Ingress count)
+                  'services.nodeports': '3' (Service type=NodePort count)
                   'configmaps': '20' (ConfigMap count)
+                  'secrets': '15' (Secret count)
+                  'persistentvolumeclaims': '8' (PVC count)
+                  'replicationcontrollers': '4' (ReplicationController count)
+                  'deployments.apps': '6' (Deployment count)
+                  'statefulsets.apps': '2' (StatefulSet count)
+                  'daemonsets.apps': '2' (DaemonSet count)
+                  'jobs.batch': '5' (Job count)
+                  'cronjobs.batch': '3' (CronJob count)
+                  'horizontalpodautoscalers.autoscaling': '2' (HPA count)
+                  'ingresses.networking.k8s.io': '3' (Ingress count)
+
                   ...and so on for all supported native and extended resource types.
-                  See documentation for the full list of supported resource keys.
                 type: object
               namespaceSelector:
                 description: |-
@@ -121,10 +150,10 @@ spec:
                 x-kubernetes-map-type: atomic
               scopeSelector:
                 description: |-
-                  ScopeSelector is also a collection of filters like scopes that must match each object tracked by a quota
-                  but expressed using ScopeSelectorOperator in combination with possible values.
-                  For example, to select objects where any container has a resource request that exceeds 100m CPU,
-                  you would use: scopeSelector.matchExpressions: [{operator: In, scopeName: PriorityClass, values: ['high']}]
+                  ScopeSelector is a collection of scope filters expressed using ScopeSelectorOperator
+                  in combination with possible values, ANDed with Scopes. Scopes filter pods only:
+                  non-pod resources in Hard are rejected at admission when any scope is set.
+                  Example: scopeSelector.matchExpressions: [{operator: In, scopeName: PriorityClass, values: ['high']}]
                 properties:
                   matchExpressions:
                     description: A list of scope selector requirements by scope of
@@ -161,22 +190,55 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: 'scopeSelector: invalid scope name'
+                  rule: self.matchExpressions.all(m, m.scopeName in ['Terminating','NotTerminating','BestEffort','NotBestEffort','PriorityClass','CrossNamespacePodAffinity'])
+                - message: 'scopeSelector: invalid operator'
+                  rule: self.matchExpressions.all(m, m.operator in ['In','NotIn','Exists','DoesNotExist'])
+                - message: 'scopeSelector: only the PriorityClass scope supports operators
+                    other than Exists'
+                  rule: self.matchExpressions.all(m, m.scopeName == 'PriorityClass'
+                    || m.operator == 'Exists')
+                - message: 'scopeSelector: values must be non-empty for In/NotIn and
+                    empty for Exists/DoesNotExist'
+                  rule: self.matchExpressions.all(m, (m.operator == 'In' || m.operator
+                    == 'NotIn') == (size(m.values) > 0))
+                - message: 'scopeSelector: BestEffort and NotBestEffort scopes are
+                    mutually exclusive'
+                  rule: '!(self.matchExpressions.exists(m, m.scopeName == ''BestEffort'')
+                    && self.matchExpressions.exists(m, m.scopeName == ''NotBestEffort''))'
+                - message: 'scopeSelector: Terminating and NotTerminating scopes are
+                    mutually exclusive'
+                  rule: '!(self.matchExpressions.exists(m, m.scopeName == ''Terminating'')
+                    && self.matchExpressions.exists(m, m.scopeName == ''NotTerminating''))'
               scopes:
                 description: |-
-                  A collection of filters that must match each object tracked by a quota.
-                  If not specified, the quota matches all objects.
+                  Scopes is a collection of filters that must all match each pod tracked by the quota.
+                  If not specified, the quota matches all pods. Scopes filter pods only.
                   Available scopes are:
                   - Terminating: match pods where spec.activeDeadlineSeconds >= 0
                   - NotTerminating: match pods where spec.activeDeadlineSeconds is nil
                   - BestEffort: match pods that have best effort quality of service
                   - NotBestEffort: match pods that do not have best effort quality of service
-                  - PriorityClass: match pods that have the specified priority class
-                  - CrossNamespacePodAffinity: match pods that have cross-namespace pod affinity terms
+                  - PriorityClass: match pods that have any priority class set
+                  - CrossNamespacePodAffinity: match pods with cross-namespace pod (anti)affinity terms
                 items:
                   description: A ResourceQuotaScope defines a filter that must match
                     each object tracked by a quota
+                  enum:
+                  - Terminating
+                  - NotTerminating
+                  - BestEffort
+                  - NotBestEffort
+                  - PriorityClass
+                  - CrossNamespacePodAffinity
                   type: string
                 type: array
+                x-kubernetes-validations:
+                - message: BestEffort and NotBestEffort scopes are mutually exclusive
+                  rule: '!(''BestEffort'' in self && ''NotBestEffort'' in self)'
+                - message: Terminating and NotTerminating scopes are mutually exclusive
+                  rule: '!(''Terminating'' in self && ''NotTerminating'' in self)'
             required:
             - namespaceSelector
             type: object

--- a/internal/controller/clusterresourcequota_controller_test.go
+++ b/internal/controller/clusterresourcequota_controller_test.go
@@ -1700,3 +1700,101 @@ var _ = Describe("calculateObjectCount with unsupported resource", func() {
 		Expect(post - pre).To(Equal(float64(1)))
 	})
 })
+
+// This suite creates CRQs against the real envtest API server, which has no
+// webhook registered — any rejection here comes solely from the CRD's own
+// OpenAPI/CEL schema, proving those rules hold even when the webhook is down.
+var _ = Describe("ClusterResourceQuota CRD scope validation", func() {
+	nsSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"team": "crd-scope-validation"}}
+
+	create := func(name string, spec quotav1alpha1.ClusterResourceQuotaSpec) error {
+		spec.NamespaceSelector = nsSelector
+		crq := &quotav1alpha1.ClusterResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       spec,
+		}
+		err := k8sClient.Create(ctx, crq)
+		if err == nil {
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, crq) })
+		}
+		return err
+	}
+
+	It("accepts a valid PriorityClass scopeSelector", func() {
+		err := create("crd-scope-valid", quotav1alpha1.ClusterResourceQuotaSpec{
+			Hard: quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")},
+			ScopeSelector: &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpIn,
+					Values:    []string{"high"},
+				}},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable("rejects invalid scopeSelector expressions",
+		func(req corev1.ScopedResourceSelectorRequirement, substr string) {
+			err := create("crd-scope-invalid", quotav1alpha1.ClusterResourceQuotaSpec{
+				Hard:          quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")},
+				ScopeSelector: &corev1.ScopeSelector{MatchExpressions: []corev1.ScopedResourceSelectorRequirement{req}},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substr))
+		},
+		Entry("unknown scope name",
+			corev1.ScopedResourceSelectorRequirement{
+				ScopeName: corev1.ResourceQuotaScope("Bogus"),
+				Operator:  corev1.ScopeSelectorOpExists,
+			}, "scopeSelector: invalid scope name"),
+		Entry("unknown operator",
+			corev1.ScopedResourceSelectorRequirement{
+				ScopeName: corev1.ResourceQuotaScopePriorityClass,
+				Operator:  corev1.ScopeSelectorOperator("Maybe"),
+			}, "scopeSelector: invalid operator"),
+		Entry("non-Exists operator on a non-PriorityClass scope",
+			corev1.ScopedResourceSelectorRequirement{
+				ScopeName: corev1.ResourceQuotaScopeBestEffort,
+				Operator:  corev1.ScopeSelectorOpIn,
+				Values:    []string{"x"},
+			}, "only the PriorityClass scope supports"),
+		Entry("In operator with no values",
+			corev1.ScopedResourceSelectorRequirement{
+				ScopeName: corev1.ResourceQuotaScopePriorityClass,
+				Operator:  corev1.ScopeSelectorOpIn,
+			}, "values must be non-empty"),
+		Entry("Exists operator with values set",
+			corev1.ScopedResourceSelectorRequirement{
+				ScopeName: corev1.ResourceQuotaScopePriorityClass,
+				Operator:  corev1.ScopeSelectorOpExists,
+				Values:    []string{"x"},
+			}, "values must be non-empty"),
+	)
+
+	It("rejects mutually exclusive scopes via the existing Scopes CEL rule", func() {
+		err := create("crd-scope-exclusive", quotav1alpha1.ClusterResourceQuotaSpec{
+			Hard: quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")},
+			Scopes: []corev1.ResourceQuotaScope{
+				corev1.ResourceQuotaScopeBestEffort,
+				corev1.ResourceQuotaScopeNotBestEffort,
+			},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+	})
+
+	It("rejects mutually exclusive scopes expressed entirely via scopeSelector, via CEL", func() {
+		err := create("crd-scopeselector-exclusive", quotav1alpha1.ClusterResourceQuotaSpec{
+			Hard: quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")},
+			ScopeSelector: &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
+					{ScopeName: corev1.ResourceQuotaScopeBestEffort, Operator: corev1.ScopeSelectorOpExists},
+					{ScopeName: corev1.ResourceQuotaScopeNotBestEffort, Operator: corev1.ScopeSelectorOpExists},
+				},
+			},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+	})
+})


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Third of a 5-PR stack splitting up the original scope-filtering PR (stacked on #139 — only this PR's own diff is new). The schema/validation layer: reviewable as "is this CRD schema correct and consistent with upstream `ResourceQuota` validation." No Go-level validation logic lives here — that's bundled with the webhook that calls it, in the next PR (#141), since it has no other caller.

**What's in here:**
- `+kubebuilder:validation:items:Enum` on `spec.scopes` restricting it to the six valid scope names.
- CEL (`XValidation`) rules on both `spec.scopes` and `spec.scopeSelector`:
  - valid scope names, valid operators, `values` cardinality per operator (empty for `Exists`/`DoesNotExist`, non-empty for `In`/`NotIn`)
  - only `PriorityClass` may use an operator other than `Exists`
  - `BestEffort`+`NotBestEffort` and `Terminating`+`NotTerminating` are mutually exclusive — enforced independently within `scopes` **and** within `scopeSelector`, matching how upstream `ResourceQuota` validates each field's internal consistency separately
- These CEL rules matter because the webhook's `failurePolicy` is `Ignore` (fail-open by design, existing project posture) — CEL is the only backstop that holds even when the webhook is unavailable, so it needs to cover the same invariants independently, not just defer to the webhook.
- An envtest suite creates CRQs directly against a real envtest API server with no webhook registered, so a rejection there can only come from the CRD's own schema — proving these rules hold on their own.

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
- [x] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed (CRD regenerated via `make manifests`, chart CRD copy re-synced)
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> Versioning belongs at the top of the stack, once the feature is fully wired up and enforced.