### PR TITLE
feat(controller,webhook): enforce quota scopes

### DIFF
--- a/internal/controller/clusterresourcequota_controller.go
+++ b/internal/controller/clusterresourcequota_controller.go
@@ -77,6 +77,16 @@ func (resourceUpdatePredicate) Update(e event.UpdateEvent) bool {
 				containerTerminated(podOld.Status.ContainerStatuses, podNew.Status.ContainerStatuses) {
 				return true
 			}
+			// activeDeadlineSeconds flips Terminating/NotTerminating scope classification but
+			// does not bump pod generation on clusters older than 1.33. This is the only
+			// mutable-post-creation field scope matching cares about (priorityClassName and
+			// affinity are immutable after creation; QoS-affecting resources are only mutable
+			// via the /resize subresource, which does bump generation), so a targeted pointer
+			// comparison catches it without an O(len(PodSpec)) DeepEqual on every pod update
+			// event cluster-wide.
+			if !activeDeadlineSecondsEqual(podOld.Spec.ActiveDeadlineSeconds, podNew.Spec.ActiveDeadlineSeconds) {
+				return true
+			}
 		}
 	}
 
@@ -99,6 +109,15 @@ func (resourceUpdatePredicate) Delete(e event.DeleteEvent) bool {
 	}
 
 	return false
+}
+
+// activeDeadlineSecondsEqual compares the only Pod spec field scope matching
+// needs to watch for post-creation mutation.
+func activeDeadlineSecondsEqual(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // containerTerminated returns true if any container in the new statuses has transitioned to Terminated
@@ -309,6 +328,13 @@ func (r *ClusterResourceQuotaReconciler) calculateAndAggregateUsage(
 		pods, svcs, pvcs, err := r.listNamespaceResources(ctx, nsName, kinds)
 		if err != nil {
 			return nil, nil, err
+		}
+
+		// Scopes constrain pods only; services/PVCs/object counts are never filtered.
+		pods, err = pod.FilterInScope(pods, crq.Spec.Scopes, crq.Spec.ScopeSelector)
+		if err != nil {
+			r.EventRecorder.InvalidScopeSelector(crq, err)
+			return nil, nil, fmt.Errorf("invalid scope selector: %w", err)
 		}
 
 		var pvcsByClass map[string][]corev1.PersistentVolumeClaim

--- a/internal/controller/clusterresourcequota_controller_test.go
+++ b/internal/controller/clusterresourcequota_controller_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	"github.com/powerhome/pac-quota-controller/pkg/events"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/objectcount"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/pod"
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/services"
@@ -23,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoevents "k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -522,6 +524,62 @@ var _ = Describe("ClusterResourceQuota Controller", Ordered, func() {
 				ObjectNew: newPod,
 			}
 			Expect(predicate.Update(event)).To(BeTrue())
+		})
+
+		It("should reconcile when activeDeadlineSeconds changes without a generation bump", func() {
+			ads := int64(300)
+			oldPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			newPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       corev1.PodSpec{ActiveDeadlineSeconds: &ads},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			event := event.UpdateEvent{
+				ObjectOld: oldPod,
+				ObjectNew: newPod,
+			}
+			Expect(predicate.Update(event)).To(BeTrue())
+		})
+
+		It("should reconcile when activeDeadlineSeconds changes between two non-nil values", func() {
+			oldADS, newADS := int64(300), int64(600)
+			oldPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       corev1.PodSpec{ActiveDeadlineSeconds: &oldADS},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			newPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       corev1.PodSpec{ActiveDeadlineSeconds: &newADS},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			event := event.UpdateEvent{
+				ObjectOld: oldPod,
+				ObjectNew: newPod,
+			}
+			Expect(predicate.Update(event)).To(BeTrue())
+		})
+
+		It("should not reconcile when activeDeadlineSeconds is unchanged and set on both sides", func() {
+			ads := int64(300)
+			oldPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       corev1.PodSpec{ActiveDeadlineSeconds: &ads},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			newPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       corev1.PodSpec{ActiveDeadlineSeconds: &ads},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			event := event.UpdateEvent{
+				ObjectOld: oldPod,
+				ObjectNew: newPod,
+			}
+			Expect(predicate.Update(event)).To(BeFalse())
 		})
 
 		It("should not reconcile for non-terminal phase changes (e.g., Pending -> Running)", func() {
@@ -1408,6 +1466,79 @@ var _ = Describe("ClusterResourceQuota Controller", Ordered, func() {
 			Expect(str(gpu)).To(Equal("2"))
 			Expect(str(fastStorage)).To(Equal("3Gi"))
 			Expect(str(fastCount)).To(Equal("2"))
+		})
+
+		It("filters pods by scopes during aggregation", func() {
+			ads := int64(300)
+			fakeClient := fake.NewClientBuilder().WithObjects(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-not-terminating", Namespace: "ns-a"},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+						},
+					}}},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-terminating", Namespace: "ns-a"},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+					Spec: corev1.PodSpec{
+						ActiveDeadlineSeconds: &ads,
+						Containers: []corev1.Container{{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+							},
+						}},
+					},
+				},
+			).Build()
+
+			r := &ClusterResourceQuotaReconciler{Client: fakeClient, logger: zap.NewNop()}
+			crq := &quotav1alpha1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "scoped"},
+				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeNotTerminating},
+					Hard: quotav1alpha1.ResourceList{
+						corev1.ResourcePods:        resource.MustParse("10"),
+						corev1.ResourceRequestsCPU: resource.MustParse("10"),
+					},
+				},
+			}
+
+			total, _, err := r.calculateAndAggregateUsage(ctx, crq, []string{"ns-a"})
+			Expect(err).NotTo(HaveOccurred())
+			pods := total[corev1.ResourcePods]
+			cpu := total[corev1.ResourceRequestsCPU]
+			Expect(pods.String()).To(Equal("1"))
+			Expect(cpu.String()).To(Equal("250m"))
+		})
+
+		It("fails reconciliation and emits an InvalidScopeSelector event for a scope spec that bypassed admission", func() {
+			fakeClient := fake.NewClientBuilder().WithObjects(
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a"}},
+			).Build()
+			fakeRecorder := clientgoevents.NewFakeRecorder(10)
+			r := &ClusterResourceQuotaReconciler{
+				Client:        fakeClient,
+				logger:        zap.NewNop(),
+				EventRecorder: events.NewEventRecorder(fakeRecorder, zap.NewNop()),
+			}
+			crq := &quotav1alpha1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid-scope"},
+				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+					// A CRQ with this scope name is rejected at admission (webhook + CEL); this
+					// simulates one that reached storage before that validation existed, per the
+					// documented fail-open behavior.
+					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScope("Bogus")},
+					Hard:   quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("10")},
+				},
+			}
+
+			_, _, err := r.calculateAndAggregateUsage(ctx, crq, []string{"ns-a"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid scope selector"))
+			Expect(fakeRecorder.Events).To(Receive(ContainSubstring("Invalid scope selector")))
 		})
 
 		It("skips namespaces with an empty name without errors", func() {

--- a/pkg/events/recorder.go
+++ b/pkg/events/recorder.go
@@ -12,11 +12,12 @@ import (
 
 const (
 	// Event reasons for ClusterResourceQuota
-	ReasonQuotaExceeded     = "QuotaExceeded"
-	ReasonNamespaceAdded    = "NamespaceAdded"
-	ReasonNamespaceRemoved  = "NamespaceRemoved"
-	ReasonCalculationFailed = "CalculationFailed"
-	ReasonInvalidSelector   = "InvalidSelector"
+	ReasonQuotaExceeded        = "QuotaExceeded"
+	ReasonNamespaceAdded       = "NamespaceAdded"
+	ReasonNamespaceRemoved     = "NamespaceRemoved"
+	ReasonCalculationFailed    = "CalculationFailed"
+	ReasonInvalidSelector      = "InvalidSelector"
+	ReasonInvalidScopeSelector = "InvalidScopeSelector"
 
 	// Event types
 	EventTypeNormal  = "Normal"
@@ -73,6 +74,14 @@ func (r *EventRecorder) CalculationFailed(crq *quotav1alpha1.ClusterResourceQuot
 func (r *EventRecorder) InvalidSelector(crq *quotav1alpha1.ClusterResourceQuota, err error) {
 	message := fmt.Sprintf("Invalid namespace selector: %v", err)
 	r.recordEvent(crq, EventTypeWarning, ReasonInvalidSelector, message)
+}
+
+// InvalidScopeSelector records an event when spec.scopes/scopeSelector is invalid.
+// This can only happen for a CRQ that reached storage before admission validation
+// existed (or while the webhook was unavailable) — see docs/quota-scopes.md.
+func (r *EventRecorder) InvalidScopeSelector(crq *quotav1alpha1.ClusterResourceQuota, err error) {
+	message := fmt.Sprintf("Invalid scope selector: %v", err)
+	r.recordEvent(crq, EventTypeWarning, ReasonInvalidScopeSelector, message)
 }
 
 // recordEvent records an event with PAC-specific labels using the current pod as the event target

--- a/pkg/events/recorder_test.go
+++ b/pkg/events/recorder_test.go
@@ -176,6 +176,28 @@ var _ = Describe("EventRecorder", func() {
 		})
 	})
 
+	Describe("InvalidScopeSelector", func() {
+		It("should record an InvalidScopeSelector event with error details", func() {
+			testErr := fmt.Errorf("invalid quota scope %q", "Bogus")
+			eventRecorder.InvalidScopeSelector(testCRQ, testErr)
+
+			Expect(fakeRecorder.Events).To(HaveLen(1))
+			event := <-fakeRecorder.Events
+			Expect(event).To(ContainSubstring("InvalidScopeSelector"))
+			Expect(event).To(ContainSubstring(`Invalid scope selector: invalid quota scope "Bogus"`))
+		})
+
+		It("should record event as Warning type", func() {
+			testErr := fmt.Errorf("scope error")
+			eventRecorder.InvalidScopeSelector(testCRQ, testErr)
+
+			Expect(fakeRecorder.Events).To(HaveLen(1))
+			event := <-fakeRecorder.Events
+			Expect(event).To(ContainSubstring("Warning"))
+			Expect(event).To(ContainSubstring("InvalidScopeSelector"))
+		})
+	})
+
 	Describe("Event Annotations", func() {
 		It("should include PAC-specific annotations on events", func() {
 			// Test with QuotaExceeded as an example

--- a/pkg/kubernetes/quota/scope_validation.go
+++ b/pkg/kubernetes/quota/scope_validation.go
@@ -1,0 +1,171 @@
+package quota
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/pod"
+	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
+)
+
+var validScopes = map[corev1.ResourceQuotaScope]bool{
+	corev1.ResourceQuotaScopeTerminating:               true,
+	corev1.ResourceQuotaScopeNotTerminating:            true,
+	corev1.ResourceQuotaScopeBestEffort:                true,
+	corev1.ResourceQuotaScopeNotBestEffort:             true,
+	corev1.ResourceQuotaScopePriorityClass:             true,
+	corev1.ResourceQuotaScopeCrossNamespacePodAffinity: true,
+}
+
+var mutuallyExclusiveScopePairs = [][2]corev1.ResourceQuotaScope{
+	{corev1.ResourceQuotaScopeBestEffort, corev1.ResourceQuotaScopeNotBestEffort},
+	{corev1.ResourceQuotaScopeTerminating, corev1.ResourceQuotaScopeNotTerminating},
+}
+
+// podScopeEligibleResources are the hard keys any pod scope other than BestEffort
+// may limit; BestEffort further restricts to pods. Mirrors upstream
+// podComputeQuotaResources in pkg/apis/core/helper/helpers.go @ release-1.36 —
+// notably, ephemeral-storage is a standard quota resource but is NOT scope-eligible.
+var podScopeEligibleResources = map[corev1.ResourceName]bool{
+	usage.ResourcePods:           true,
+	usage.ResourceRequestsCPU:    true,
+	usage.ResourceRequestsMemory: true,
+	usage.ResourceLimitsCPU:      true,
+	usage.ResourceLimitsMemory:   true,
+}
+
+// standardNonScopeResources are standard quota resources that no scope may restrict.
+var standardNonScopeResources = map[corev1.ResourceName]bool{
+	usage.ResourceRequestsEphemeralStorage: true,
+	usage.ResourceLimitsEphemeralStorage:   true,
+	usage.ResourceServices:                 true,
+	usage.ResourceServicesLoadBalancers:    true,
+	usage.ResourceServicesNodePorts:        true,
+	usage.ResourceRequestsStorage:          true,
+	usage.ResourcePersistentVolumeClaims:   true,
+	usage.ResourceConfigMaps:               true,
+	usage.ResourceSecrets:                  true,
+	usage.ResourceReplicationControllers:   true,
+	usage.ResourceDeployments:              true,
+	usage.ResourceStatefulSets:             true,
+	usage.ResourceDaemonSets:               true,
+	usage.ResourceJobs:                     true,
+	usage.ResourceCronJobs:                 true,
+	usage.ResourceHorizontalPodAutoscalers: true,
+	usage.ResourceIngresses:                true,
+}
+
+// isStandardQuotaResource mirrors upstream IsStandardQuotaResourceName: extended
+// resources (requests.<domain>/<res>, hugepages-*) bypass scope restrictions.
+func isStandardQuotaResource(name corev1.ResourceName) bool {
+	return podScopeEligibleResources[name] || standardNonScopeResources[name] ||
+		strings.Contains(string(name), ".storageclass.storage.k8s.io/")
+}
+
+func scopeAllowsResource(scope corev1.ResourceQuotaScope, name corev1.ResourceName) bool {
+	if !isStandardQuotaResource(name) {
+		return true
+	}
+	if scope == corev1.ResourceQuotaScopeBestEffort {
+		return name == usage.ResourcePods
+	}
+	return podScopeEligibleResources[name]
+}
+
+// ValidateScopeSpec validates spec.scopes and spec.scopeSelector, mirroring
+// upstream ValidateResourceQuotaSpec (pkg/apis/core/validation/validation.go
+// @ release-1.36). A non-nil error rejects the CRQ; warnings flag legal-but-suspect
+// combinations upstream does not check.
+func ValidateScopeSpec(crq *quotav1alpha1.ClusterResourceQuota) ([]string, error) {
+	seen := map[corev1.ResourceQuotaScope]bool{}
+	for _, s := range crq.Spec.Scopes {
+		if !validScopes[s] {
+			return nil, fmt.Errorf("spec.scopes: invalid quota scope %q", s)
+		}
+		if seen[s] {
+			return nil, fmt.Errorf("spec.scopes: duplicate scope %q", s)
+		}
+		seen[s] = true
+	}
+	if err := rejectMutuallyExclusive("spec.scopes", seen); err != nil {
+		return nil, err
+	}
+
+	selSeen := map[corev1.ResourceQuotaScope]bool{}
+	if sel := crq.Spec.ScopeSelector; sel != nil {
+		for _, req := range sel.MatchExpressions {
+			if err := validateScopeRequirement(req); err != nil {
+				return nil, err
+			}
+			selSeen[req.ScopeName] = true
+		}
+	}
+	// Upstream validates each field's internal consistency independently; a
+	// contradiction living entirely within scopeSelector is its own hard error,
+	// same as one entirely within scopes.
+	if err := rejectMutuallyExclusive("spec.scopeSelector", selSeen); err != nil {
+		return nil, err
+	}
+
+	all := pod.BuildScopeRequirements(crq.Spec.Scopes, crq.Spec.ScopeSelector)
+	for _, req := range all {
+		for name := range crq.Spec.Hard {
+			if !scopeAllowsResource(req.ScopeName, name) {
+				return nil, fmt.Errorf("unsupported scope %s applied to resource %q", req.ScopeName, name)
+			}
+		}
+	}
+
+	// Upstream does not check contradictions that span both fields (one scope via
+	// `scopes`, its opposite via `scopeSelector`); such a quota is legal but matches
+	// no pods, so it's surfaced here as an admission warning instead.
+	var warnings []string
+	names := map[corev1.ResourceQuotaScope]bool{}
+	for _, req := range all {
+		names[req.ScopeName] = true
+	}
+	for _, pair := range mutuallyExclusiveScopePairs {
+		if names[pair[0]] && names[pair[1]] {
+			warnings = append(warnings,
+				fmt.Sprintf("scopes %s and %s together match no pods; the quota will never accrue usage",
+					pair[0], pair[1]))
+		}
+	}
+	return warnings, nil
+}
+
+func rejectMutuallyExclusive(fld string, present map[corev1.ResourceQuotaScope]bool) error {
+	for _, pair := range mutuallyExclusiveScopePairs {
+		if present[pair[0]] && present[pair[1]] {
+			return fmt.Errorf("%s: %s and %s are mutually exclusive", fld, pair[0], pair[1])
+		}
+	}
+	return nil
+}
+
+func validateScopeRequirement(req corev1.ScopedResourceSelectorRequirement) error {
+	if !validScopes[req.ScopeName] {
+		return fmt.Errorf("spec.scopeSelector: invalid quota scope %q", req.ScopeName)
+	}
+	switch req.Operator {
+	case corev1.ScopeSelectorOpIn, corev1.ScopeSelectorOpNotIn:
+		if len(req.Values) == 0 {
+			return fmt.Errorf("spec.scopeSelector: operator %s requires values for scope %q",
+				req.Operator, req.ScopeName)
+		}
+	case corev1.ScopeSelectorOpExists, corev1.ScopeSelectorOpDoesNotExist:
+		if len(req.Values) != 0 {
+			return fmt.Errorf("spec.scopeSelector: operator %s must not have values for scope %q",
+				req.Operator, req.ScopeName)
+		}
+	default:
+		return fmt.Errorf("spec.scopeSelector: invalid operator %q", req.Operator)
+	}
+	if req.ScopeName != corev1.ResourceQuotaScopePriorityClass && req.Operator != corev1.ScopeSelectorOpExists {
+		return fmt.Errorf("spec.scopeSelector: scope %q only supports the Exists operator", req.ScopeName)
+	}
+	return nil
+}

--- a/pkg/kubernetes/quota/scope_validation_test.go
+++ b/pkg/kubernetes/quota/scope_validation_test.go
@@ -1,0 +1,177 @@
+package quota
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+)
+
+func scopedCRQ(
+	hard quotav1alpha1.ResourceList,
+	scopes []corev1.ResourceQuotaScope,
+	sel *corev1.ScopeSelector,
+) *quotav1alpha1.ClusterResourceQuota {
+	return &quotav1alpha1.ClusterResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "crq"},
+		Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+			Hard:          hard,
+			Scopes:        scopes,
+			ScopeSelector: sel,
+		},
+	}
+}
+
+var _ = Describe("ValidateScopeSpec", func() {
+	podsHard := quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")}
+	computeHard := quotav1alpha1.ResourceList{
+		corev1.ResourcePods:        resource.MustParse("5"),
+		corev1.ResourceRequestsCPU: resource.MustParse("2"),
+	}
+
+	DescribeTable("rejections",
+		func(crq *quotav1alpha1.ClusterResourceQuota, substr string) {
+			_, err := ValidateScopeSpec(crq)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substr))
+		},
+		Entry("invalid scope name via scopes",
+			scopedCRQ(podsHard, []corev1.ResourceQuotaScope{"Bogus"}, nil),
+			"invalid quota scope"),
+		Entry("invalid scope name via scopeSelector",
+			scopedCRQ(podsHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScope("Bogus"),
+					Operator:  corev1.ScopeSelectorOpExists,
+				}},
+			}),
+			"invalid quota scope"),
+		Entry("duplicate scope",
+			scopedCRQ(podsHard, []corev1.ResourceQuotaScope{
+				corev1.ResourceQuotaScopeBestEffort, corev1.ResourceQuotaScopeBestEffort}, nil),
+			"duplicate scope"),
+		Entry("BestEffort with NotBestEffort",
+			scopedCRQ(podsHard, []corev1.ResourceQuotaScope{
+				corev1.ResourceQuotaScopeBestEffort, corev1.ResourceQuotaScopeNotBestEffort}, nil),
+			"mutually exclusive"),
+		Entry("Terminating with NotTerminating",
+			scopedCRQ(podsHard, []corev1.ResourceQuotaScope{
+				corev1.ResourceQuotaScopeTerminating, corev1.ResourceQuotaScopeNotTerminating}, nil),
+			"mutually exclusive"),
+		Entry("BestEffort with NotBestEffort entirely within scopeSelector",
+			scopedCRQ(podsHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
+					{ScopeName: corev1.ResourceQuotaScopeBestEffort, Operator: corev1.ScopeSelectorOpExists},
+					{ScopeName: corev1.ResourceQuotaScopeNotBestEffort, Operator: corev1.ScopeSelectorOpExists},
+				},
+			}),
+			"mutually exclusive"),
+		Entry("non-Exists operator on BestEffort",
+			scopedCRQ(podsHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopeBestEffort,
+					Operator:  corev1.ScopeSelectorOpIn,
+					Values:    []string{"x"},
+				}},
+			}),
+			"only supports the Exists operator"),
+		Entry("In without values",
+			scopedCRQ(podsHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpIn,
+				}},
+			}),
+			"requires values"),
+		Entry("Exists with values",
+			scopedCRQ(podsHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpExists,
+					Values:    []string{"x"},
+				}},
+			}),
+			"must not have values"),
+		Entry("invalid operator",
+			scopedCRQ(podsHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOperator("Maybe"),
+				}},
+			}),
+			"invalid operator"),
+		Entry("services under a Terminating scope",
+			scopedCRQ(quotav1alpha1.ResourceList{
+				corev1.ResourcePods:     resource.MustParse("5"),
+				corev1.ResourceServices: resource.MustParse("5"),
+			}, []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating}, nil),
+			"unsupported scope"),
+		Entry("compute resource under BestEffort",
+			scopedCRQ(computeHard, []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort}, nil),
+			"unsupported scope"),
+		Entry("ephemeral-storage under a Terminating scope",
+			scopedCRQ(quotav1alpha1.ResourceList{
+				corev1.ResourcePods:                     resource.MustParse("5"),
+				corev1.ResourceRequestsEphemeralStorage: resource.MustParse("1Gi"),
+			}, []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating}, nil),
+			"unsupported scope"),
+		Entry("storage-class resource under a scopeSelector",
+			scopedCRQ(quotav1alpha1.ResourceList{
+				corev1.ResourceName("fast.storageclass.storage.k8s.io/requests.storage"): resource.MustParse("1Gi"),
+			}, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpExists,
+				}},
+			}),
+			"unsupported scope"),
+	)
+
+	DescribeTable("accepted",
+		func(crq *quotav1alpha1.ClusterResourceQuota) {
+			warnings, err := ValidateScopeSpec(crq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		},
+		Entry("no scopes with any resources",
+			scopedCRQ(quotav1alpha1.ResourceList{
+				corev1.ResourceServices: resource.MustParse("5"),
+			}, nil, nil)),
+		Entry("Terminating with pod compute resources",
+			scopedCRQ(computeHard, []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating}, nil)),
+		Entry("BestEffort with pods only",
+			scopedCRQ(podsHard, []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort}, nil)),
+		Entry("extended resource bypasses the restriction",
+			scopedCRQ(quotav1alpha1.ResourceList{
+				corev1.ResourcePods:                            resource.MustParse("5"),
+				corev1.ResourceName("requests.nvidia.com/gpu"): resource.MustParse("4"),
+			}, []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeNotTerminating}, nil)),
+		Entry("PriorityClass In via scopeSelector",
+			scopedCRQ(computeHard, nil, &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpIn,
+					Values:    []string{"high"},
+				}},
+			})),
+	)
+
+	It("warns on contradictory scopes across scopes and scopeSelector", func() {
+		crq := scopedCRQ(podsHard,
+			[]corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
+			&corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopeNotBestEffort,
+					Operator:  corev1.ScopeSelectorOpExists,
+				}},
+			})
+		warnings, err := ValidateScopeSpec(crq)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0]).To(ContainSubstring("match no pods"))
+	})
+})

--- a/pkg/webhook/v1alpha1/clusterresourcequota_webhook.go
+++ b/pkg/webhook/v1alpha1/clusterresourcequota_webhook.go
@@ -52,9 +52,6 @@ func (h *ClusterResourceQuotaWebhook) Handle(c *gin.Context) {
 	}, h.validate)
 }
 
-// TODO: the []string return is a future-proofing placeholder for admission
-// warnings. Once any validator actually emits warnings, plumb them through
-// runWebhook into AdmissionResponse.Warnings.
 func (h *ClusterResourceQuotaWebhook) validate(
 	ctx context.Context,
 	req *admissionv1.AdmissionRequest,
@@ -66,7 +63,7 @@ func (h *ClusterResourceQuotaWebhook) validate(
 
 	switch req.Operation {
 	case admissionv1.Create, admissionv1.Update:
-		return nil, h.validateOperation(ctx, &crq)
+		return h.validateOperation(ctx, &crq)
 	default:
 		// Unknown operations (e.g. DELETE) are intentionally allowed; the
 		// ValidatingWebhookConfiguration only registers CREATE/UPDATE so this
@@ -81,14 +78,19 @@ func (h *ClusterResourceQuotaWebhook) validate(
 func (h *ClusterResourceQuotaWebhook) validateOperation(
 	ctx context.Context,
 	crq *quotav1alpha1.ClusterResourceQuota,
-) error {
+) ([]string, error) {
 	if h.crqClient == nil {
-		return fmt.Errorf("CRQ client not available for validation")
+		return nil, fmt.Errorf("CRQ client not available for validation")
+	}
+
+	warnings, err := quota.ValidateScopeSpec(crq)
+	if err != nil {
+		return warnings, err
 	}
 
 	validator := namespace.NewNamespaceValidator(h.client, h.crqClient)
 	if err := validator.ValidateCRQNamespaceConflicts(ctx, crq); err != nil {
-		return err
+		return warnings, err
 	}
-	return nil
+	return warnings, nil
 }

--- a/pkg/webhook/v1alpha1/clusterresourcequota_webhook_test.go
+++ b/pkg/webhook/v1alpha1/clusterresourcequota_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,8 +96,48 @@ var _ = Describe("ClusterResourceQuotaWebhook", func() {
 				},
 			}
 
-			err := webhook.validateOperation(ctx, crq)
+			_, err := webhook.validateOperation(ctx, crq)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject a scoped CRQ with non-pod resources", func() {
+			crq := &quotav1alpha1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "scoped-crq"},
+				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+					Hard: quotav1alpha1.ResourceList{
+						"pods":     resource.MustParse("5"),
+						"services": resource.MustParse("5"),
+					},
+					Scopes:            []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating},
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+				},
+			}
+
+			_, err := webhook.validateOperation(ctx, crq)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported scope"))
+		})
+
+		It("should surface warnings for contradictory scope combinations", func() {
+			crq := &quotav1alpha1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "contradictory-crq"},
+				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+					Hard:   quotav1alpha1.ResourceList{"pods": resource.MustParse("5")},
+					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
+					ScopeSelector: &corev1.ScopeSelector{
+						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+							ScopeName: corev1.ResourceQuotaScopeNotBestEffort,
+							Operator:  corev1.ScopeSelectorOpExists,
+						}},
+					},
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+				},
+			}
+
+			warnings, err := webhook.validateOperation(ctx, crq)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring("match no pods"))
 		})
 	})
 
@@ -119,7 +160,7 @@ var _ = Describe("ClusterResourceQuotaWebhook", func() {
 				},
 			}
 
-			err := webhook.validateOperation(ctx, crq)
+			_, err := webhook.validateOperation(ctx, crq)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/webhook/v1alpha1/pod_webhook.go
+++ b/pkg/webhook/v1alpha1/pod_webhook.go
@@ -93,6 +93,22 @@ func (h *PodWebhook) validateOperation(
 		return nil, nil
 	}
 
+	// Scope membership is stable for every request this webhook sees: resize cannot
+	// change QoS class, and activeDeadlineSeconds/priorityClassName/affinity are not
+	// reachable through CREATE-then-resize, so the old pod never needs re-evaluation.
+	inScope, err := pod.PodInScope(podObj, crq.Spec.Scopes, crq.Spec.ScopeSelector)
+	if err != nil {
+		// Fail-open: an invalid scope spec should have been rejected at CRQ admission.
+		h.logger.Warn("Invalid CRQ scope selector - allowing pod",
+			zap.String("crq_name", crq.Name), zap.Error(err))
+		return nil, nil
+	}
+	if !inScope {
+		h.logger.Debug("Pod outside CRQ scopes; skipping quota validation",
+			zap.String("crq_name", crq.Name), zap.String("pod", podObj.Name))
+		return nil, nil
+	}
+
 	correlationID := quota.GetCorrelationID(ctx)
 
 	computeResources := []struct {

--- a/pkg/webhook/v1alpha1/pod_webhook_test.go
+++ b/pkg/webhook/v1alpha1/pod_webhook_test.go
@@ -502,4 +502,58 @@ var _ = Describe("PodWebhook", func() {
 			Expect(resp.Response.Allowed).To(BeTrue())
 		})
 	})
+
+	Describe("scoped CRQ", func() {
+		fullBestEffortCRQ := func() *quotav1alpha1.ClusterResourceQuota {
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{usage.ResourcePods: quantity("2")},
+				quotav1alpha1.ResourceList{usage.ResourcePods: quantity("2")},
+			)
+			crq.Spec.Scopes = []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort}
+			return crq
+		}
+
+		It("denies an in-scope pod when the scoped quota is full", func() {
+			h := NewPodWebhook(newTestCRQClient(makeNamespace(nsName, labels), fullBestEffortCRQ()), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPodReview("s1", makePod("be", "", "", "", "")))
+			Expect(resp.Response.Allowed).To(BeFalse())
+		})
+
+		It("allows an out-of-scope pod even when the scoped quota is full", func() {
+			h := NewPodWebhook(newTestCRQClient(makeNamespace(nsName, labels), fullBestEffortCRQ()), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPodReview("s2", makePod("burstable", "100m", "", "", "")))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("allows a pod outside a Terminating scope regardless of usage", func() {
+			crq := makeCRQ(crqName, labels,
+				quotav1alpha1.ResourceList{usage.ResourceRequestsCPU: quantity("1")},
+				quotav1alpha1.ResourceList{usage.ResourceRequestsCPU: quantity("1")},
+			)
+			crq.Spec.Scopes = []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating}
+			h := NewPodWebhook(newTestCRQClient(makeNamespace(nsName, labels), crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPodReview("s3", makePod("no-deadline", "500m", "", "", "")))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+
+		It("fails open when the CRQ scope spec is invalid", func() {
+			crq := fullBestEffortCRQ()
+			crq.Spec.ScopeSelector = &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
+					{ScopeName: corev1.ResourceQuotaScope("Bogus"), Operator: corev1.ScopeSelectorOpExists},
+				},
+			}
+			h := NewPodWebhook(newTestCRQClient(makeNamespace(nsName, labels), crq), zap.NewNop())
+			engine.POST("/webhook", h.Handle)
+
+			resp := sendWebhookRequest(engine, newPodReview("s4", makePod("be", "", "", "", "")))
+			Expect(resp.Response.Allowed).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Fourth of a 5-PR stack splitting up the original scope-filtering PR (stacked on #140 — only this PR's own diff is new). This is the integration layer: wires the matcher (#139) and schema (#140) into actual enforcement, both at reconcile time and at admission time. Reviewable as "is scope filtering correctly wired into the paths that actually matter."

**What's in here:**
- **Controller:** `calculateAndAggregateUsage` filters each namespace's pod slice through `pod.FilterInScope` right after listing, before any per-resource usage computation — so every pod-derived resource (`pods` count, `requests.cpu`, etc.) sees the same filtered slice, not just the pod-count. If the scope spec is invalid (a CRQ that reached storage before validation existed, or while the webhook was down), reconciliation fails with a dedicated `InvalidScopeSelector` event rather than a silently-wrong result.
- The reconcile predicate now also reacts to `activeDeadlineSeconds` changes via a targeted pointer comparison — this field can flip `Terminating`/`NotTerminating` scope membership without bumping pod `generation` on clusters older than 1.33, and it's the *only* mutable-post-creation field scope matching needs to watch (priority class and affinity are immutable after creation; QoS-affecting resource changes go through `/resize`, which does bump generation). Deliberately not a full `PodSpec` comparison — this predicate runs on every pod update event cluster-wide (single shared informer, no namespace scoping), so a full diff would be a real always-on cost for the one field that actually matters.
- **Pod webhook:** allows an out-of-scope pod without charging it against the quota, even when the quota is full. Scope membership is stable across every request this webhook actually sees (`CREATE` and `UPDATE` on `pods/resize` only — never a general pod update, confirmed against the actual `ValidatingWebhookConfiguration`), so it only needs to check the new pod state.
- **CRQ webhook:** validates `spec.scopes`/`spec.scopeSelector` (`pkg/kubernetes/quota/scope_validation.go`) mirroring upstream `ResourceQuota` validation — rejects scoped quotas with non-pod `hard` resources (ephemeral-storage is correctly excluded here too, matching upstream's `podComputeQuotaResources`, not just cpu/memory-adjacent resources loosely construed), and surfaces contradictory-but-legal `scopes`+`scopeSelector` combinations as an admission warning rather than a rejection.

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (ensure e2e tests pass - not included in pre-commit)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> **⚠️ Behavior change on upgrade** (fully proven end-to-end in #142): scopes stored before this feature existed were silently ignored; after upgrading they become enforced. `status.total.used` may drop for existing scoped CRQs (out-of-scope pods stop counting), and any existing scoped CRQ that also limits non-pod resources will be rejected on its next update. Worth calling out in release notes when the full stack ships. Versioning bump belongs at the top of the stack (#142).