### PR TITLE
docs,test(e2e): document and cover scoped ClusterResourceQuota

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The ClusterResourceQuota controller mimics the Kubernetes ResourceQuota mechanis
 - Support for all standard Kubernetes resource types (pods, services, etc.)
 - Support for compute resources (CPU, memory)
 - Support for storage resources (PVCs)
+- Support for ResourceQuota `scopes` and `scopeSelector` (pod-scoped quotas, see [docs/quota-scopes.md](docs/quota-scopes.md))
 - Automatic aggregation of resource usage across namespaces
 
 ## Usage

--- a/docs/quota-scopes.md
+++ b/docs/quota-scopes.md
@@ -1,0 +1,105 @@
+# Quota Scopes Support in pac-quota-controller
+
+## Overview
+
+`ClusterResourceQuota` supports the standard Kubernetes ResourceQuota `scopes` and `scopeSelector` fields. Scopes restrict which **pods** count toward the quota; a pod is tracked only if it matches **all** declared scopes. Scopes never filter non-pod resources (services, PVCs, object counts), and quotas combining scopes with non-pod resources in `hard` are rejected at admission.
+
+## Supported Scopes
+
+| Scope | Matches pods where |
+|---|---|
+| `Terminating` | `spec.activeDeadlineSeconds >= 0` |
+| `NotTerminating` | `spec.activeDeadlineSeconds` is nil |
+| `BestEffort` | computed QoS class is BestEffort (no cpu/memory requests or limits) |
+| `NotBestEffort` | computed QoS class is Burstable or Guaranteed |
+| `PriorityClass` | a `spec.priorityClassName` is set (or matches the selector values) |
+| `CrossNamespacePodAffinity` | any pod (anti)affinity term sets `namespaces` or `namespaceSelector` |
+
+Entries in `scopes` behave as `Exists` requirements. `scopeSelector.matchExpressions` supports operators per scope: `PriorityClass` accepts `In`, `NotIn`, `Exists`, `DoesNotExist`; all other scopes accept only `Exists`. All requirements from both fields are ANDed.
+
+## How it Works
+
+- **Controller:** during aggregation the pod list of each selected namespace is filtered through the scope requirements before usage is computed, so `status.total.used` reflects only in-scope, non-terminal pods.
+- **Pod webhook:** at admission, an out-of-scope pod is allowed without charging the quota — even when the quota is full. In-scope pods are charged against `status.total.used` as usual.
+- **QoS classification** is always computed from the pod spec (never `status.qosClass`), so admission and reconciliation agree.
+
+## Validation Rules
+
+Rejected at CRQ admission (mirroring upstream `ResourceQuota` validation):
+
+- unknown scope names or duplicate scopes
+- `BestEffort` + `NotBestEffort`, or `Terminating` + `NotTerminating`, within `scopes` alone or within `scopeSelector` alone (the `scopes`-only case is also enforced by CRD CEL rules, which hold even if the webhook is unavailable)
+- unsupported operators (only `PriorityClass` accepts more than `Exists`), missing/extra `values`
+- non-pod resources in `hard` when any scope is set: allowed keys are `pods` plus compute resources (`requests.`/`limits.` cpu and memory only — ephemeral-storage is not scope-eligible, matching upstream). `BestEffort`-scoped quotas may only limit `pods` (best-effort pods have no requests/limits by definition)
+- extended resources (`requests.<domain>/<resource>`, `hugepages-*`) bypass the restriction, exactly as upstream, and are scope-filtered like other pod resources
+
+Contradictory combinations across `scopes` and `scopeSelector` (e.g. `scopes: [BestEffort]` with a `NotBestEffort` expression) are legal but produce an admission **warning** — such a quota matches no pods.
+
+If an invalid scope spec reaches storage anyway (the webhooks are fail-open), the controller fails reconciliation with an `InvalidScopeSelector` event and the pod webhook allows pods for that CRQ; non-pod resources in `hard` are counted unfiltered.
+
+## Usage in ClusterResourceQuota
+
+```yaml
+# Cap CI/batch pods (those with an active deadline)
+apiVersion: quota.powerapp.cloud/v1alpha1
+kind: ClusterResourceQuota
+metadata:
+  name: ci-jobs-quota
+spec:
+  namespaceSelector:
+    matchLabels:
+      team: ci
+  scopes: [Terminating]
+  hard:
+    pods: "20"
+    requests.cpu: "10"
+```
+
+```yaml
+# Limit best-effort pods (only 'pods' is allowed under BestEffort)
+spec:
+  namespaceSelector:
+    matchLabels:
+      team: web
+  scopes: [BestEffort]
+  hard:
+    pods: "5"
+```
+
+```yaml
+# Quota only for high-priority workloads
+spec:
+  namespaceSelector:
+    matchLabels:
+      team: web
+  scopeSelector:
+    matchExpressions:
+      - scopeName: PriorityClass
+        operator: In
+        values: [high, critical]
+  hard:
+    pods: "10"
+    requests.cpu: "8"
+```
+
+See `examples/scoped-quota-example.yaml` for a complete example.
+
+## Status Reporting
+
+`status.total.used` and the per-namespace breakdown count only in-scope pods. An out-of-scope pod is invisible to the quota: it is neither counted nor denied.
+
+## Key Differences and Limitations
+
+- A namespace can be owned by only **one** CRQ, so a BestEffort quota and a NotBestEffort quota cannot both cover the same namespace (stock ResourceQuota allows multiple scoped quotas per namespace).
+- Quota is enforced at admission time. A pod that enters a scope mid-life (e.g. `activeDeadlineSeconds` patched onto a running pod) is picked up by the next reconcile and can push `used` above `hard` — the same behavior as stock ResourceQuota.
+- **Upgrade note:** scopes stored before this feature existed were silently ignored; after upgrading they are enforced. `used` may drop (out-of-scope pods stop counting) and previously-stored scoped CRQs with non-pod `hard` keys will be rejected on their next update.
+
+## Testing
+
+```sh
+# Unit tests (matcher, QoS, validation)
+go test ./pkg/kubernetes/pod/ ./pkg/kubernetes/quota/
+
+# E2E tests
+make test-e2e  # includes test/e2e/scoped_quota_test.go
+```

--- a/docs/quota-scopes.md
+++ b/docs/quota-scopes.md
@@ -97,8 +97,8 @@ See `examples/scoped-quota-example.yaml` for a complete example.
 ## Testing
 
 ```sh
-# Unit tests (matcher, QoS, validation)
-go test ./pkg/kubernetes/pod/ ./pkg/kubernetes/quota/
+# Unit tests (matcher, QoS, validation, resource classification)
+go test ./pkg/kubernetes/pod/ ./pkg/kubernetes/quota/ ./pkg/kubernetes/usage/
 
 # E2E tests
 make test-e2e  # includes test/e2e/scoped_quota_test.go

--- a/examples/scoped-quota-example.yaml
+++ b/examples/scoped-quota-example.yaml
@@ -1,0 +1,51 @@
+# Scoped ClusterResourceQuota examples.
+# Scopes filter pods only: a pod counts toward the quota when it matches ALL scopes.
+---
+# Quota for non-best-effort pods (pods with cpu/memory requests or limits).
+apiVersion: quota.powerapp.cloud/v1alpha1
+kind: ClusterResourceQuota
+metadata:
+  name: not-best-effort-quota
+spec:
+  namespaceSelector:
+    matchLabels:
+      quota-example: scoped
+  scopes: [NotBestEffort]
+  hard:
+    pods: "10"
+    requests.cpu: "4"
+    requests.memory: 8Gi
+---
+# Example namespace targeted by the quota above.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scoped-quota-demo
+  labels:
+    quota-example: scoped
+---
+# Burstable pod: in scope, charged against not-best-effort-quota.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: in-scope-burstable
+  namespace: scoped-quota-demo
+spec:
+  containers:
+    - name: app
+      image: nginx:latest
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+---
+# Best-effort pod: out of scope, admitted and never counted by the quota.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: out-of-scope-best-effort
+  namespace: scoped-quota-demo
+spec:
+  containers:
+    - name: app
+      image: nginx:latest

--- a/test/e2e/scoped_quota_test.go
+++ b/test/e2e/scoped_quota_test.go
@@ -1,0 +1,235 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	quotav1alpha1 "github.com/powerhome/pac-quota-controller/api/v1alpha1"
+	testutils "github.com/powerhome/pac-quota-controller/test/utils"
+)
+
+var _ = Describe("Scoped ClusterResourceQuota Tests", func() {
+	var (
+		testNamespace string
+		testSuffix    string
+		nsLabels      map[string]string
+		ns            *corev1.Namespace
+	)
+
+	createScopedCRQ := func(
+		name string,
+		hard quotav1alpha1.ResourceList,
+		scopes []corev1.ResourceQuotaScope,
+		sel *corev1.ScopeSelector,
+	) *quotav1alpha1.ClusterResourceQuota {
+		crq := &quotav1alpha1.ClusterResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+				NamespaceSelector: &metav1.LabelSelector{MatchLabels: nsLabels},
+				Hard:              hard,
+				Scopes:            scopes,
+				ScopeSelector:     sel,
+			},
+		}
+		Expect(k8sClient.Create(ctx, crq)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, crq) })
+		return crq
+	}
+
+	BeforeEach(func() {
+		testSuffix = testutils.GenerateTestSuffix()
+		testNamespace = testutils.GenerateResourceName("scope-ns-" + testSuffix)
+		nsLabels = map[string]string{"scope-test": "test-label-" + testSuffix}
+
+		var err error
+		ns, err = testutils.CreateNamespace(ctx, k8sClient, testNamespace, nsLabels)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, ns) })
+	})
+
+	Context("BestEffort scope", func() {
+		It("counts and enforces only best-effort pods", func() {
+			crqName := testutils.GenerateResourceName("scope-crq-" + testSuffix)
+			createScopedCRQ(crqName,
+				quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("2")},
+				[]corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort}, nil)
+
+			for _, name := range []string{"be-1-" + testSuffix, "be-2-" + testSuffix} {
+				pod, err := testutils.CreatePod(ctx, k8sClient, testNamespace, name, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, pod) })
+			}
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName, corev1.ResourcePods, resource.MustParse("2"),
+			)).To(Succeed())
+
+			// Third best-effort pod exceeds the scoped count.
+			err := testutils.EventuallyDenied(ctx, k8sClient, func() (client.Object, error) {
+				return testutils.CreatePod(ctx, k8sClient, testNamespace, "be-3-"+testSuffix, nil, nil)
+			})
+			Expect(err.Error()).To(ContainSubstring("pods limit exceeded"))
+
+			// A burstable pod is out of scope and admitted even though the quota is full.
+			pod, err := testutils.CreatePod(ctx, k8sClient, testNamespace, "burstable-"+testSuffix,
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m")}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pod) })
+
+			// The out-of-scope pod never shows up in usage.
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName, corev1.ResourcePods, resource.MustParse("2"),
+			)).To(Succeed())
+		})
+	})
+
+	Context("Terminating scope", func() {
+		makePodWithADS := func(name, cpu string, ads *int64) *corev1.Pod {
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+				Spec: corev1.PodSpec{
+					ActiveDeadlineSeconds: ads,
+					Containers: []corev1.Container{{
+						Name:  "test-container",
+						Image: "nginx:latest",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(cpu)},
+						},
+					}},
+				},
+			}
+		}
+
+		It("only charges pods with an active deadline", func() {
+			ads := int64(600)
+			crqName := testutils.GenerateResourceName("scope-crq-" + testSuffix)
+			createScopedCRQ(crqName,
+				quotav1alpha1.ResourceList{corev1.ResourceRequestsCPU: resource.MustParse("100m")},
+				[]corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating}, nil)
+
+			// Out of scope: no deadline, exceeds the cpu limit on its own, still admitted.
+			nonTerminating := makePodWithADS("no-ads-"+testSuffix, "200m", nil)
+			Expect(k8sClient.Create(ctx, nonTerminating)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, nonTerminating) })
+
+			// In scope: charged against the quota.
+			terminating := makePodWithADS("ads-1-"+testSuffix, "60m", &ads)
+			Expect(k8sClient.Create(ctx, terminating)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, terminating) })
+
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName, corev1.ResourceRequestsCPU, resource.MustParse("60m"),
+			)).To(Succeed())
+
+			// Second in-scope pod would exceed 100m.
+			err := testutils.EventuallyDenied(ctx, k8sClient, func() (client.Object, error) {
+				pod := makePodWithADS(testutils.GenerateResourceName("ads-2"), "60m", &ads)
+				return pod, k8sClient.Create(ctx, pod)
+			})
+			Expect(err.Error()).To(ContainSubstring("CPU requests validation failed"))
+		})
+	})
+
+	Context("PriorityClass scopeSelector", func() {
+		It("only charges pods with a matching priority class", func() {
+			pcName := "scope-high-" + testSuffix
+			pc := &schedulingv1.PriorityClass{
+				ObjectMeta: metav1.ObjectMeta{Name: pcName},
+				Value:      1000,
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, pc) })
+
+			crqName := testutils.GenerateResourceName("scope-crq-" + testSuffix)
+			createScopedCRQ(crqName,
+				quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+				nil,
+				&corev1.ScopeSelector{
+					MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+						ScopeName: corev1.ResourceQuotaScopePriorityClass,
+						Operator:  corev1.ScopeSelectorOpIn,
+						Values:    []string{pcName},
+					}},
+				})
+
+			priorityPod := func(name string) *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+					Spec: corev1.PodSpec{
+						PriorityClassName: pcName,
+						Containers: []corev1.Container{{
+							Name:  "test-container",
+							Image: "nginx:latest",
+						}},
+					},
+				}
+			}
+
+			first := priorityPod("prio-1-" + testSuffix)
+			Expect(k8sClient.Create(ctx, first)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, first) })
+
+			Expect(testutils.WaitForCRQResourceUsage(
+				ctx, k8sClient, crqName, corev1.ResourcePods, resource.MustParse("1"),
+			)).To(Succeed())
+
+			err := testutils.EventuallyDenied(ctx, k8sClient, func() (client.Object, error) {
+				pod := priorityPod(testutils.GenerateResourceName("prio-2"))
+				return pod, k8sClient.Create(ctx, pod)
+			})
+			Expect(err.Error()).To(ContainSubstring("pods limit exceeded"))
+
+			// No priority class: out of scope, admitted despite the full quota.
+			plain, err := testutils.CreatePod(ctx, k8sClient, testNamespace, "plain-"+testSuffix, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, plain) })
+		})
+	})
+
+	Context("Scope spec validation", func() {
+		It("rejects a scoped CRQ with non-pod resources via the webhook", func() {
+			crq := &quotav1alpha1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: testutils.GenerateResourceName("bad-crq-" + testSuffix)},
+				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: nsLabels},
+					Hard: quotav1alpha1.ResourceList{
+						corev1.ResourcePods:     resource.MustParse("5"),
+						corev1.ResourceServices: resource.MustParse("5"),
+					},
+					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating},
+				},
+			}
+			err := k8sClient.Create(ctx, crq)
+			if err == nil {
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, crq) })
+			}
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported scope"))
+		})
+
+		It("rejects mutually exclusive scopes via CRD CEL validation", func() {
+			crq := &quotav1alpha1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: testutils.GenerateResourceName("cel-crq-" + testSuffix)},
+				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: nsLabels},
+					Hard:              quotav1alpha1.ResourceList{corev1.ResourcePods: resource.MustParse("5")},
+					Scopes: []corev1.ResourceQuotaScope{
+						corev1.ResourceQuotaScopeBestEffort,
+						corev1.ResourceQuotaScopeNotBestEffort,
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, crq)
+			if err == nil {
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, crq) })
+			}
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+		})
+	})
+})


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Last of a 5-PR stack splitting up the original scope-filtering PR (stacked on #141 — only this PR's own diff is new). Top of the stack: proves the fully-assembled feature (#138–#141 combined) end-to-end and documents it for users. This is the first point in the stack where a real cluster exercises the whole thing together.

**What's in here:**
- `docs/quota-scopes.md` — full semantics, validation rules (including the ephemeral-storage exclusion and the scopeSelector-only mutual-exclusion rejection from #141), usage examples, and the documented upgrade/limitation caveats.
- `examples/scoped-quota-example.yaml` — a runnable example (`NotBestEffort` scope).
- `test/e2e/scoped_quota_test.go` — real-cluster coverage for `BestEffort`, `Terminating`, and `PriorityClass` (via `scopeSelector`) scopes, plus both rejection paths (webhook business-rule rejection, CRD CEL rejection). This intentionally doesn't re-test all six scopes at the e2e level: `BestEffort`/`Terminating`/`PriorityClass` already exercise every distinct wiring path (plain-list matching, scopeSelector-operator matching, compute-resource charging, pod-count charging), and the scope-specific *semantics* for `NotTerminating`/`NotBestEffort`/`CrossNamespacePodAffinity` are already exhaustively covered at the unit level in #139.
- README feature-list line pointing at the docs.

**Full stack e2e result:** 97 passed, 0 failed, 2 skipped (pre-existing skips unrelated to this change) — run against this PR's branch with the entire stack assembled.

## 📚 Documentation

- [x] 📖 Updated documentation (`docs/quota-scopes.md`, README features list)
- [x] 📄 Added examples (`examples/scoped-quota-example.yaml`)

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior (e2e: `test/e2e/scoped_quota_test.go`)
- [x] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [x] `make test-e2e` (97 passed, 0 failed, 2 pre-existing skips unrelated to this change)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)

> Left unchecked deliberately — versioning is manual per CONTRIBUTING.md and the enforcement behavior change (see #141) should be called out explicitly whenever this is released.