### PR TITLE
fix(e2e): raise controller resource limits and add flake retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ deps: envtest golangci-lint mockery ## Install all development dependencies
 .PHONY: test-e2e
 # Run the e2e suite. The Go suite owns the cluster lifecycle; this is just an alias.
 test-e2e:
-	E2E_IMG=$(IMG) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	E2E_IMG=$(IMG) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -timeout=20m -ginkgo.v -ginkgo.flake-attempts=2
 
 .PHONY: lint
 lint: generate golangci-lint ## Run golangci-lint linter

--- a/test/e2e/storage_class_quota_test.go
+++ b/test/e2e/storage_class_quota_test.go
@@ -21,6 +21,7 @@ import (
 var _ = Describe("Storage Class Quota E2E Tests", func() {
 	var (
 		testNamespace      string
+		testNamespaceLabel string
 		storageClassFast   string
 		storageClassSlow   string
 		storageClassCustom string
@@ -61,6 +62,10 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 
 	BeforeEach(func() {
 		testNamespace = fmt.Sprintf("storage-class-test-%s", testutils.GenerateTestSuffix())
+		// Unique per test run: a fixed label value would let a still-terminating
+		// namespace from a previous run/retry match this run's CRQ selector too,
+		// double-counting its PVCs against a fresh quota.
+		testNamespaceLabel = "enabled-" + testutils.GenerateTestSuffix()
 		storageClassFast = fmt.Sprintf("fast-ssd-e2e-%s", testutils.GenerateTestSuffix())
 		storageClassSlow = fmt.Sprintf("slow-hdd-e2e-%s", testutils.GenerateTestSuffix())
 		storageClassCustom = fmt.Sprintf("custom-nvme-e2e-%s", testutils.GenerateTestSuffix())
@@ -71,7 +76,7 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testNamespace,
 				Labels: map[string]string{
-					"storage-class-test": "enabled",
+					"storage-class-test": testNamespaceLabel,
 					"e2e-test":           "storage-quota",
 				},
 			},
@@ -105,7 +110,7 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"storage-class-test": "enabled",
+							"storage-class-test": testNamespaceLabel,
 						},
 					},
 					Hard: quotav1alpha1.ResourceList{
@@ -232,7 +237,7 @@ var _ = Describe("Storage Class Quota E2E Tests", func() {
 				Spec: quotav1alpha1.ClusterResourceQuotaSpec{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"storage-class-test": "enabled",
+							"storage-class-test": testNamespaceLabel,
 						},
 					}, Hard: quotav1alpha1.ResourceList{
 						// Only storage quota for fast SSD (no count limit)

--- a/test/utils/cluster.go
+++ b/test/utils/cluster.go
@@ -153,6 +153,11 @@ func (c E2EConfig) DeployChart(ctx context.Context, root string) error {
 		"--set", "controllerManager.container.image.repository="+repo,
 		"--set", "controllerManager.container.image.tag="+tag,
 		"--set", "controllerManager.container.image.pullPolicy=Never",
+		// e2e-only headroom bump: the chart's default 500m/128Mi is tight under
+		// MaxConcurrentReconciles fan-out during the suite's event load, which was
+		// throttling/delaying reconciles enough to cause CI timeouts.
+		"--set", "controllerManager.container.resources.limits.cpu=1",
+		"--set", "controllerManager.container.resources.limits.memory=512Mi",
 		"--wait", "--timeout", "10m0s")
 }
 


### PR DESCRIPTION
## 📖 Description

`E2E Tests` has been intermittently failing on unrelated commits (renovate digest bumps, chore commits) on `main` and other branches — a different random spec each time (storage-class quota, PVC webhook, object-count/configmaps), plus occasional `SynchronizedBeforeSuite` aborts (0 specs run).

Root cause: the controller-manager's default resource limits (`500m`/`128Mi`, `charts/pac-quota-controller/values.yaml`) are tight under `MaxConcurrentReconciles: 5` fanning out across 14 cluster-wide watches, most of which are currently unfiltered, on a 2 vCPU/7GB GitHub-hosted runner shared with dockerd, the kind node, and the test binary. This is enough to throttle/delay reconciliation past the suite's 60-180s polling timeouts.

Changes:
- `test/utils/cluster.go`: bump the e2e-only Helm deploy's controller-manager resource limits to `1` CPU / `512Mi` (production chart defaults in `values.yaml` are untouched).
- `Makefile`: add `-ginkgo.flake-attempts=2` (a spec only fails if it fails twice in a row) and `-timeout=20m` (today's unset `go test` default of 10m is shorter than the worst-case sum of the suite's own nested provisioning timeouts).

A follow-up PR (separate, off `main`) will address the underlying reconciler event-handling cost (unindexed CRQ lookup on every watched-object event, missing predicates on 13 of 14 watches) — this PR is scoped to the CI harness only.

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (verified via CI on this PR)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)