### PR TITLE
refactor(quota): consolidate scope and resource lookup tables

### DIFF
--- a/internal/controller/clusterresourcequota_controller.go
+++ b/internal/controller/clusterresourcequota_controller.go
@@ -379,27 +379,19 @@ func (r *ClusterResourceQuotaReconciler) classifyKindsNeeded(hard quotav1alpha1.
 	var k namespaceKinds
 	for resourceName := range hard {
 		resourceStr := string(resourceName)
-		switch resourceName {
-		case corev1.ResourceRequestsCPU,
-			corev1.ResourceRequestsMemory,
-			corev1.ResourceLimitsCPU,
-			corev1.ResourceLimitsMemory,
-			corev1.ResourcePods:
+		switch {
+		case usage.PodEligibleResources[resourceName]:
 			k.pods = true
-		case usage.ResourceServices,
-			usage.ResourceServicesLoadBalancers,
-			usage.ResourceServicesNodePorts:
+		case usage.ServiceResources[resourceName]:
 			k.services = true
-		case corev1.ResourceRequestsStorage, usage.ResourcePersistentVolumeClaims:
+		case usage.PVCResources[resourceName]:
 			k.pvcs = true
-		default:
-			if r.isComputeResource(resourceName) {
-				k.pods = true
-			} else if strings.HasSuffix(resourceStr, ".storageclass.storage.k8s.io/requests.storage") ||
-				strings.HasSuffix(resourceStr, ".storageclass.storage.k8s.io/persistentvolumeclaims") {
-				k.pvcs = true
-				k.storageClasses = true
-			}
+		case r.isComputeResource(resourceName):
+			k.pods = true
+		case strings.HasSuffix(resourceStr, ".storageclass.storage.k8s.io/requests.storage"),
+			strings.HasSuffix(resourceStr, ".storageclass.storage.k8s.io/persistentvolumeclaims"):
+			k.pvcs = true
+			k.storageClasses = true
 		}
 	}
 	return k
@@ -520,18 +512,7 @@ func (r *ClusterResourceQuotaReconciler) calculateObjectCount(
 	ctx context.Context, ns string, resourceName corev1.ResourceName,
 ) (resource.Quantity, error) {
 	// Use the correct calculator for each resource type
-	switch resourceName {
-	case usage.ResourceConfigMaps, usage.ResourceSecrets, usage.ResourceReplicationControllers,
-		usage.ResourceDeployments, usage.ResourceStatefulSets, usage.ResourceDaemonSets,
-		usage.ResourceJobs, usage.ResourceCronJobs, usage.ResourceHorizontalPodAutoscalers, usage.ResourceIngresses:
-		objectCount, err := r.ObjectCountCalculator.CalculateUsage(ctx, ns, resourceName)
-		if err != nil {
-			r.logger.Error("Failed to calculate object count usage",
-				zap.Error(err), zap.Stringer("resource", resourceName), zap.String("namespace", ns))
-			return resource.Quantity{}, err
-		}
-		return objectCount, nil
-	default:
+	if !usage.ObjectCountResources[resourceName] {
 		// CRQ tracks a resource we have no calculator for (typo or unsupported kind).
 		// Return zero to keep the rest of the reconcile working, but emit a Warn +
 		// metric so operators can detect the silent admit.
@@ -542,6 +523,14 @@ func (r *ClusterResourceQuotaReconciler) calculateObjectCount(
 		)
 		return resource.MustParse("0"), nil
 	}
+
+	objectCount, err := r.ObjectCountCalculator.CalculateUsage(ctx, ns, resourceName)
+	if err != nil {
+		r.logger.Error("Failed to calculate object count usage",
+			zap.Error(err), zap.Stringer("resource", resourceName), zap.String("namespace", ns))
+		return resource.Quantity{}, err
+	}
+	return objectCount, nil
 }
 
 // updateStatus updates the status of the ClusterResourceQuota object.

--- a/pkg/kubernetes/pod/scope.go
+++ b/pkg/kubernetes/pod/scope.go
@@ -13,6 +13,19 @@ func HasScopes(scopes []corev1.ResourceQuotaScope, sel *corev1.ScopeSelector) bo
 	return len(scopes) > 0 || (sel != nil && len(sel.MatchExpressions) > 0)
 }
 
+// ValidScopes are the ResourceQuotaScope values podMatchesScopeRequirement
+// knows how to match. The single source of truth for "is this scope name
+// valid" — callers validating a scope spec (e.g. quota.ValidateScopeSpec)
+// should check membership here rather than keeping a second copy.
+var ValidScopes = map[corev1.ResourceQuotaScope]bool{
+	corev1.ResourceQuotaScopeTerminating:               true,
+	corev1.ResourceQuotaScopeNotTerminating:            true,
+	corev1.ResourceQuotaScopeBestEffort:                true,
+	corev1.ResourceQuotaScopeNotBestEffort:             true,
+	corev1.ResourceQuotaScopePriorityClass:             true,
+	corev1.ResourceQuotaScopeCrossNamespacePodAffinity: true,
+}
+
 // BuildScopeRequirements normalizes plain scopes (each an implicit Exists) and
 // scopeSelector.matchExpressions into a single ANDed requirement list.
 func BuildScopeRequirements(

--- a/pkg/kubernetes/pod/scope_test.go
+++ b/pkg/kubernetes/pod/scope_test.go
@@ -38,6 +38,15 @@ func selectorWith(reqs ...corev1.ScopedResourceSelectorRequirement) *corev1.Scop
 }
 
 var _ = Describe("Scope matching", func() {
+	Describe("ValidScopes", func() {
+		It("should be dispatched by podMatchesScopeRequirement without an 'invalid quota scope' error", func() {
+			for scope := range ValidScopes {
+				_, err := PodInScope(bestEffortPod(), []corev1.ResourceQuotaScope{scope}, nil)
+				Expect(err).NotTo(HaveOccurred(), "scope %q is in ValidScopes but not handled by the matcher switch", scope)
+			}
+		})
+	})
+
 	Describe("HasScopes", func() {
 		It("should be false without scopes or selector", func() {
 			Expect(HasScopes(nil, nil)).To(BeFalse())

--- a/pkg/kubernetes/quota/scope_validation.go
+++ b/pkg/kubernetes/quota/scope_validation.go
@@ -11,57 +11,23 @@ import (
 	"github.com/powerhome/pac-quota-controller/pkg/kubernetes/usage"
 )
 
-var validScopes = map[corev1.ResourceQuotaScope]bool{
-	corev1.ResourceQuotaScopeTerminating:               true,
-	corev1.ResourceQuotaScopeNotTerminating:            true,
-	corev1.ResourceQuotaScopeBestEffort:                true,
-	corev1.ResourceQuotaScopeNotBestEffort:             true,
-	corev1.ResourceQuotaScopePriorityClass:             true,
-	corev1.ResourceQuotaScopeCrossNamespacePodAffinity: true,
-}
-
 var mutuallyExclusiveScopePairs = [][2]corev1.ResourceQuotaScope{
 	{corev1.ResourceQuotaScopeBestEffort, corev1.ResourceQuotaScopeNotBestEffort},
 	{corev1.ResourceQuotaScopeTerminating, corev1.ResourceQuotaScopeNotTerminating},
 }
 
-// podScopeEligibleResources are the hard keys any pod scope other than BestEffort
-// may limit; BestEffort further restricts to pods. Mirrors upstream
-// podComputeQuotaResources in pkg/apis/core/helper/helpers.go @ release-1.36 —
-// notably, ephemeral-storage is a standard quota resource but is NOT scope-eligible.
-var podScopeEligibleResources = map[corev1.ResourceName]bool{
-	usage.ResourcePods:           true,
-	usage.ResourceRequestsCPU:    true,
-	usage.ResourceRequestsMemory: true,
-	usage.ResourceLimitsCPU:      true,
-	usage.ResourceLimitsMemory:   true,
-}
-
-// standardNonScopeResources are standard quota resources that no scope may restrict.
-var standardNonScopeResources = map[corev1.ResourceName]bool{
-	usage.ResourceRequestsEphemeralStorage: true,
-	usage.ResourceLimitsEphemeralStorage:   true,
-	usage.ResourceServices:                 true,
-	usage.ResourceServicesLoadBalancers:    true,
-	usage.ResourceServicesNodePorts:        true,
-	usage.ResourceRequestsStorage:          true,
-	usage.ResourcePersistentVolumeClaims:   true,
-	usage.ResourceConfigMaps:               true,
-	usage.ResourceSecrets:                  true,
-	usage.ResourceReplicationControllers:   true,
-	usage.ResourceDeployments:              true,
-	usage.ResourceStatefulSets:             true,
-	usage.ResourceDaemonSets:               true,
-	usage.ResourceJobs:                     true,
-	usage.ResourceCronJobs:                 true,
-	usage.ResourceHorizontalPodAutoscalers: true,
-	usage.ResourceIngresses:                true,
-}
-
 // isStandardQuotaResource mirrors upstream IsStandardQuotaResourceName: extended
 // resources (requests.<domain>/<res>, hugepages-*) bypass scope restrictions.
+// Ephemeral-storage is a standard quota resource but, per upstream
+// podComputeQuotaResources, is not eligible under any scope — see
+// usage.PodEligibleResources.
 func isStandardQuotaResource(name corev1.ResourceName) bool {
-	return podScopeEligibleResources[name] || standardNonScopeResources[name] ||
+	return usage.PodEligibleResources[name] ||
+		usage.ServiceResources[name] ||
+		usage.PVCResources[name] ||
+		usage.ObjectCountResources[name] ||
+		name == usage.ResourceRequestsEphemeralStorage ||
+		name == usage.ResourceLimitsEphemeralStorage ||
 		strings.Contains(string(name), ".storageclass.storage.k8s.io/")
 }
 
@@ -72,7 +38,7 @@ func scopeAllowsResource(scope corev1.ResourceQuotaScope, name corev1.ResourceNa
 	if scope == corev1.ResourceQuotaScopeBestEffort {
 		return name == usage.ResourcePods
 	}
-	return podScopeEligibleResources[name]
+	return usage.PodEligibleResources[name]
 }
 
 // ValidateScopeSpec validates spec.scopes and spec.scopeSelector, mirroring
@@ -82,7 +48,7 @@ func scopeAllowsResource(scope corev1.ResourceQuotaScope, name corev1.ResourceNa
 func ValidateScopeSpec(crq *quotav1alpha1.ClusterResourceQuota) ([]string, error) {
 	seen := map[corev1.ResourceQuotaScope]bool{}
 	for _, s := range crq.Spec.Scopes {
-		if !validScopes[s] {
+		if !pod.ValidScopes[s] {
 			return nil, fmt.Errorf("spec.scopes: invalid quota scope %q", s)
 		}
 		if seen[s] {
@@ -147,7 +113,7 @@ func rejectMutuallyExclusive(fld string, present map[corev1.ResourceQuotaScope]b
 }
 
 func validateScopeRequirement(req corev1.ScopedResourceSelectorRequirement) error {
-	if !validScopes[req.ScopeName] {
+	if !pod.ValidScopes[req.ScopeName] {
 		return fmt.Errorf("spec.scopeSelector: invalid quota scope %q", req.ScopeName)
 	}
 	switch req.Operator {

--- a/pkg/kubernetes/usage/usage.go
+++ b/pkg/kubernetes/usage/usage.go
@@ -49,6 +49,48 @@ var (
 	ResourceServicesNodePorts     = corev1.ResourceServicesNodePorts
 )
 
+// PodEligibleResources are the resources whose usage is computed from pod specs.
+// They're also the only resources a pod scope (other than BestEffort, which
+// further narrows to just pods) may restrict in spec.hard — ephemeral-storage
+// is pod-derived too but deliberately excluded from scope eligibility,
+// matching upstream's podComputeQuotaResources.
+var PodEligibleResources = map[corev1.ResourceName]bool{
+	ResourcePods:           true,
+	ResourceRequestsCPU:    true,
+	ResourceRequestsMemory: true,
+	ResourceLimitsCPU:      true,
+	ResourceLimitsMemory:   true,
+}
+
+// ServiceResources are resource names whose usage is computed from Services.
+var ServiceResources = map[corev1.ResourceName]bool{
+	ResourceServices:              true,
+	ResourceServicesLoadBalancers: true,
+	ResourceServicesNodePorts:     true,
+}
+
+// PVCResources are resource names whose usage is computed from
+// PersistentVolumeClaims, excluding the per-storage-class variants
+// (*.storageclass.storage.k8s.io/*), which are matched by suffix instead.
+var PVCResources = map[corev1.ResourceName]bool{
+	ResourceRequestsStorage:        true,
+	ResourcePersistentVolumeClaims: true,
+}
+
+// ObjectCountResources are resource names tracked via a plain List+len object count.
+var ObjectCountResources = map[corev1.ResourceName]bool{
+	ResourceConfigMaps:               true,
+	ResourceSecrets:                  true,
+	ResourceReplicationControllers:   true,
+	ResourceDeployments:              true,
+	ResourceStatefulSets:             true,
+	ResourceDaemonSets:               true,
+	ResourceJobs:                     true,
+	ResourceCronJobs:                 true,
+	ResourceHorizontalPodAutoscalers: true,
+	ResourceIngresses:                true,
+}
+
 // GetBaseResourceName returns the base resource name for a given resource name.
 // For example, it maps 'requests.cpu' or 'limits.cpu' to 'cpu'.
 func GetBaseResourceName(resourceName corev1.ResourceName) corev1.ResourceName {

--- a/pkg/kubernetes/usage/usage_test.go
+++ b/pkg/kubernetes/usage/usage_test.go
@@ -33,6 +33,62 @@ var _ = Describe("Usage", func() {
 		})
 	})
 
+	Describe("Resource category tables", func() {
+		It("should mark pod-derived compute resources as pod-eligible", func() {
+			Expect(PodEligibleResources[ResourcePods]).To(BeTrue())
+			Expect(PodEligibleResources[ResourceRequestsCPU]).To(BeTrue())
+			Expect(PodEligibleResources[ResourceRequestsMemory]).To(BeTrue())
+			Expect(PodEligibleResources[ResourceLimitsCPU]).To(BeTrue())
+			Expect(PodEligibleResources[ResourceLimitsMemory]).To(BeTrue())
+		})
+
+		It("should exclude ephemeral-storage from pod-eligible resources", func() {
+			// Pod-derived, but upstream's podComputeQuotaResources deliberately
+			// excludes it from scope eligibility.
+			Expect(PodEligibleResources[ResourceRequestsEphemeralStorage]).To(BeFalse())
+			Expect(PodEligibleResources[ResourceLimitsEphemeralStorage]).To(BeFalse())
+		})
+
+		It("should categorize service resources", func() {
+			Expect(ServiceResources[ResourceServices]).To(BeTrue())
+			Expect(ServiceResources[ResourceServicesLoadBalancers]).To(BeTrue())
+			Expect(ServiceResources[ResourceServicesNodePorts]).To(BeTrue())
+			Expect(ServiceResources[ResourcePods]).To(BeFalse())
+		})
+
+		It("should categorize PVC resources", func() {
+			Expect(PVCResources[ResourceRequestsStorage]).To(BeTrue())
+			Expect(PVCResources[ResourcePersistentVolumeClaims]).To(BeTrue())
+			Expect(PVCResources[ResourcePods]).To(BeFalse())
+		})
+
+		It("should categorize object-count resources", func() {
+			for _, name := range []corev1.ResourceName{
+				ResourceConfigMaps, ResourceSecrets, ResourceReplicationControllers,
+				ResourceDeployments, ResourceStatefulSets, ResourceDaemonSets,
+				ResourceJobs, ResourceCronJobs, ResourceHorizontalPodAutoscalers, ResourceIngresses,
+			} {
+				Expect(ObjectCountResources[name]).To(BeTrue(), "expected %s to be an object-count resource", name)
+			}
+			Expect(ObjectCountResources[ResourcePods]).To(BeFalse())
+		})
+
+		It("should not overlap between categories", func() {
+			for name := range PodEligibleResources {
+				Expect(ServiceResources[name]).To(BeFalse())
+				Expect(PVCResources[name]).To(BeFalse())
+				Expect(ObjectCountResources[name]).To(BeFalse())
+			}
+			for name := range ServiceResources {
+				Expect(PVCResources[name]).To(BeFalse())
+				Expect(ObjectCountResources[name]).To(BeFalse())
+			}
+			for name := range PVCResources {
+				Expect(ObjectCountResources[name]).To(BeFalse())
+			}
+		})
+	})
+
 	Describe("GetBaseResourceName", func() {
 		It("should strip 'requests.' prefix", func() {
 			Expect(GetBaseResourceName(corev1.ResourceRequestsCPU)).To(Equal(corev1.ResourceCPU))


### PR DESCRIPTION
# 📝 Pull Request

## 📖 Description

Follow-up to #141, stacked between it and #142 (only this PR's own diff is new). Pure DRY cleanup surfaced during #141's review — no behavior change.

**What's in here:**
- `pod.ValidScopes` is now exported and is the single source of truth for valid scope names; `quota.ValidateScopeSpec` previously kept its own private copy of the same 6-entry map, which could silently drift from the matcher's dispatch switch in `pod/scope.go`. Added a regression test that walks every `ValidScopes` key through the matcher and fails if any of them would incorrectly hit the "invalid quota scope" error path.
- New `usage.PodEligibleResources`/`ServiceResources`/`PVCResources`/`ObjectCountResources` tables replace three independently hand-maintained resource-name classifications: the controller's `classifyKindsNeeded` (decides what to List()) and `calculateObjectCount` (pre-existing, predates this stack), and #141's own `isStandardQuotaResource`/`scopeAllowsResource` (decides scope eligibility). All three were enumerating the same resource names for different purposes; now there's one table per category.
- Ephemeral-storage's quirky status — pod-derived usage-wise, but explicitly excluded from pod-scope eligibility per upstream's `podComputeQuotaResources` — is preserved and called out explicitly in `isStandardQuotaResource`'s comment, since it's the one resource that doesn't fit cleanly into the shared categories.

No behavior change: the full existing test suite (controller, quota, pod, usage, webhook, events) passes unmodified, plus new direct unit tests for the new tables.

## 📚 Documentation

- [ ] 📖 Updated documentation
- [ ] 📄 Added examples

### Testing & Validation

- [x] ✅ Added or updated tests for new/changed behavior
- [ ] 📚 Updated documentation and Helm chart if APIs, CRDs, or configuration changed
- [x] 🔧 Ran pre-commit hooks to validate changes:
  - [x] `pre-commit run --all-files` (runs formatting, linting, generation, and unit tests)
  - [ ] `make test-e2e` (not needed — no CRD/API/webhook-visible behavior change)

### Versioning & Release

- [ ] 📊 Bumped chart `version` in `charts/pac-quota-controller/Chart.yaml` if making a chart change
- [ ] 🏷️ Bumped `appVersion` in `charts/pac-quota-controller/Chart.yaml` if releasing a new application version
- [ ] 🔖 Tagged the release as `vX.Y.Z` for app releases or `chart-vX.Y.Z` for chart-only releases (if applicable)